### PR TITLE
Fix code blocks so they all use the language selection blocks. 

### DIFF
--- a/advanced-predict.md
+++ b/advanced-predict.md
@@ -10,6 +10,8 @@ If you submit a request with not an exact match of the concept id or name, you w
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.predict(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/metro-north.jpg', {
@@ -21,16 +23,22 @@ app.models.predict(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/metro-n
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, Concept
 app = ClarifaiApp(api_key='YOUR_API_KEY')
 
 model = app.models.get('general-v1.3')
- 
+
 select_concept_list = [Concept(concept_name='train'), Concept(concept_id='ai_6kTjGfF6')]
 model.predict_by_url(url='https://samples.clarifai.com/metro-north.jpg', select_concepts=select_concept_list)
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 client.predict(client.getDefaultModels().generalModel().id())
     .withInputs(ClarifaiInput.forImage("https://samples.clarifai.com/metro-north.jpg"))
@@ -38,6 +46,9 @@ client.predict(client.getDefaultModels().generalModel().id())
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -69,10 +80,16 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Coming Soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiURLImage;
@@ -94,7 +111,7 @@ if ($response->isSuccessful()) {
     $output = $response->get();
 
     echo "Predicted concepts:\n";
-    
+
     foreach ($output->data() as $concept) {
         echo $concept->name() . ': ' . $concept->value() . "\n";
     }
@@ -106,6 +123,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 curl -X POST \
   -H 'authorization: Key YOUR_API_KEY' \
@@ -133,10 +153,14 @@ curl -X POST \
 }'\
 https://api.clarifai.com/v2/models/aaa03c23b3724a16a56b629203edc62c/outputs
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -197,6 +221,8 @@ https://api.clarifai.com/v2/models/aaa03c23b3724a16a56b629203edc62c/outputs
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### Maximum Concepts
 
@@ -205,6 +231,8 @@ Setting the max concepts parameter will customize how many concepts and their co
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.predict(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/metro-north.jpg', { maxConcepts: 3 })
@@ -217,6 +245,9 @@ app.models.predict(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/metro-n
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -227,6 +258,9 @@ model.predict_by_url(url='https://samples.clarifai.com/metro-north.jpg', max_con
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.predict(client.getDefaultModels().generalModel().id())
@@ -236,6 +270,9 @@ client.predict(client.getDefaultModels().generalModel().id())
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -262,12 +299,18 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 //Coming soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiURLImage;
@@ -302,6 +345,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -329,10 +375,14 @@ curl -X POST \
   https://api.clarifai.com/v2/models/aaa03c23b3724a16a56b629203edc62c/outputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 
 {
   "status": {
@@ -401,6 +451,8 @@ curl -X POST \
 }
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### Minimum Prediction Value
 
@@ -408,6 +460,8 @@ This parameter lets you set a minimum probability threshold for the outputs you 
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.predict(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/metro-north.jpg', { minValue: 0.97 })
@@ -419,6 +473,9 @@ app.models.predict(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/metro-n
   });
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_CLARIFAI_KEY')
@@ -429,6 +486,9 @@ model.predict_by_url(url='https://samples.clarifai.com/metro-north.jpg', min_val
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.predict(client.getDefaultModels().generalModel().id())
@@ -438,6 +498,9 @@ client.predict(client.getDefaultModels().generalModel().id())
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -464,12 +527,18 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 //Coming soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -506,6 +575,9 @@ if ($response->isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -533,10 +605,14 @@ curl -X POST \
   https://api.clarifai.com/v2/models/aaa03c23b3724a16a56b629203edc62c/outputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 
 {
   "status": {
@@ -635,14 +711,18 @@ curl -X POST \
 }
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### By Model Version ID
-Every time you train a custom model, it creates a new model version. By specifying `version id` in your predict call, you can continue to predict on a previous version, for consistent prediction results. Clarifai also updates our pre-built models on a regular basis.  
+Every time you train a custom model, it creates a new model version. By specifying `version id` in your predict call, you can continue to predict on a previous version, for consistent prediction results. Clarifai also updates our pre-built models on a regular basis.
 
-If you are looking for consistent results from your predict calls, use `version id`. If the model `version id` is not specified, predict will default to the most current model. 
+If you are looking for consistent results from your predict calls, use `version id`. If the model `version id` is not specified, predict will default to the most current model.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 let app = new Clarifai.App({apiKey: 'YOUR_API_KEY'});
 
@@ -656,6 +736,9 @@ app.models.predict({id:'MODEL_ID', version:'MODEL_VERSION_ID'}, "https://samples
 );
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -666,6 +749,9 @@ model.model_version = 'YOUR_MODEL_VERSION_ID'
 response = model.predict_by_url('https://samples.clarifai.com/metro-north.jpg')
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 ModelVersion modelVersion = client.getModelVersionByID("MODEL_ID", "MODEL_VERSION_ID")
@@ -677,6 +763,9 @@ ModelVersion modelVersion = client.getModelVersionByID("MODEL_ID", "MODEL_VERSIO
         .withInputs(ClarifaiInput.forImage("https://samples.clarifai.com/metro-north.jpg"))
         .executeSync();
 ```
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -703,12 +792,18 @@ namespace YourNamespace
 
 
 ```
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 //Coming soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiURLImage;
@@ -742,6 +837,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -762,5 +860,5 @@ curl -X POST \
   https://api.clarifai.com/v2/models/<model_id>/versions/<model_version_id>/outputs
 
 ```
-
-
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/advanced-searches.md
+++ b/advanced-searches.md
@@ -7,6 +7,8 @@ predictions.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.search([
@@ -31,6 +33,9 @@ app.inputs.search([
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_CLARIFAI_KEY')
@@ -52,6 +57,9 @@ app.inputs.search_by_predicted_concepts(concepts=['cat', 'dog'], values=[True, F
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 // Search concept by name
@@ -77,6 +85,9 @@ client.searchInputs(SearchClause.matchConcept(Concept.forID("cat").withValue(fal
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -113,6 +124,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 // First create a search term with a concept you want to search.
@@ -128,6 +142,9 @@ ClarifaiSearchTerm *searchTerm = [ClarifaiSearchTerm searchByPredictedConcept:co
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Searches\SearchBy;
@@ -168,6 +185,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -194,6 +214,8 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -204,6 +226,8 @@ search by those concepts.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.search([
@@ -230,6 +254,9 @@ app.inputs.search([
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_CLARIFAI_KEY')
@@ -251,6 +278,9 @@ app.inputs.search_by_annotated_concepts(concepts=['cat', 'dog'], values=[True, F
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 // Search concept by name
@@ -276,6 +306,9 @@ client.searchInputs(SearchClause.matchUserTaggedConcept(Concept.forID("cat").wit
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -314,6 +347,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 // If you have previously added inputs tagged with "dog", you can search for them by the same tag.
@@ -329,6 +365,9 @@ ClarifaiSearchTerm *term = [ClarifaiSearchTerm searchInputsByConcept:concept];
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Searches\SearchBy;
@@ -370,6 +409,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -396,6 +438,8 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -406,6 +450,8 @@ how similar the results are to the image you provided in your query.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.search(
@@ -425,6 +471,9 @@ app.inputs.search(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_CLARIFAI_KEY')
@@ -454,6 +503,9 @@ app.inputs.search_by_image(fileobj=fio)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 // Search by image URL (String or java.net.URL)
@@ -468,6 +520,9 @@ client.searchInputs(SearchClause.matchImageVisually(ClarifaiImage.of(new File("i
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.IO;
@@ -500,6 +555,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiSearchTerm *searchTerm = [ClarifaiSearchTerm searchVisuallyWithImageURL:@"https://samples.clarifai.com/metro-north.jpg"];
@@ -513,6 +571,9 @@ ClarifaiSearchTerm *searchTerm = [ClarifaiSearchTerm searchVisuallyWithImageURL:
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Searches\SearchBy;
@@ -541,6 +602,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -567,6 +631,8 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -576,6 +642,8 @@ based upon on how similar the results are to the crop of the image you provide i
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.inputs.search(
   {
@@ -594,6 +662,9 @@ app.inputs.search(
 );
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -603,6 +674,9 @@ search = app.inputs.search_by_image(url='https://samples.clarifai.com/puppy.jpg'
 print search
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 client.searchInputs(SearchClause.matchImageVisually(ClarifaiImage.of("https://samples.clarifai.com/puppy.jpg")
     .withCrop(Crop.create()
@@ -617,6 +691,9 @@ client.searchInputs(SearchClause.matchImageVisually(ClarifaiImage.of("https://sa
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -643,10 +720,16 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Coming Soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Crop;
@@ -677,6 +760,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 curl -X POST \
   -H 'authorization: Key YOUR_API_KEY' \
@@ -694,13 +780,15 @@ curl -X POST \
                 }
             }
           }
-        }  
+        }
       }
     ]
   }
 }'\
 https://api.clarifai.com/v2/searches
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -710,6 +798,8 @@ You can combine a search to find inputs that have concepts you have supplied as 
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.search([
@@ -737,6 +827,9 @@ app.inputs.search([
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, InputSearchTerm, OutputSearchTerm, SearchQueryBuilder
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -751,6 +844,9 @@ app.inputs.search(query)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.searchInputs()
@@ -764,6 +860,9 @@ client.searchInputs()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -789,6 +888,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiConcept *conceptFromGeneralModel = [[ClarifaiConcept alloc] initWithConceptName:@"fast"];
@@ -806,6 +908,9 @@ ClarifaiSearchTerm *term2 = [ClarifaiSearchTerm searchByPredictedConcept:concept
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Searches\SearchBy;
@@ -834,6 +939,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -872,6 +980,8 @@ curl -X POST \
 https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -929,6 +1039,8 @@ How to perform searches:
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 // Search with only metadata
@@ -987,6 +1099,9 @@ app.inputs.search([
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, InputSearchTerm, OutputSearchTerm, SearchQueryBuilder
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1007,6 +1122,9 @@ app.inputs.search(query)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 JsonObject metadata = new JsonObject();
@@ -1018,6 +1136,9 @@ List<SearchHit> hits = client
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1045,6 +1166,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 // Search by metadata only.
@@ -1071,10 +1195,16 @@ ClarifaiSearchTerm *searchTerm2 = [ClarifaiSearchTerm searchInputsWithMetadata:@
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 // Coming soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -1099,6 +1229,8 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1108,6 +1240,8 @@ You can also search for an input by URL.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.search(
@@ -1128,6 +1262,9 @@ app.inputs.search(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1137,6 +1274,9 @@ app.inputs.search_by_metadata(meta)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 // Lookup images with this URL
@@ -1146,6 +1286,9 @@ client.searchInputs(SearchClause.matchImageURL(ClarifaiImage.of("https://samples
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1170,6 +1313,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 
@@ -1184,6 +1330,9 @@ ClarifaiSearchTerm *term = [ClarifaiSearchTerm searchInputsWithImageURL:@"https:
 }];
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Searches\SearchBy;
@@ -1212,6 +1361,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -1236,6 +1388,8 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1265,6 +1419,8 @@ GPS coordinate system (SRID 4326). There can be at most one single geo point ass
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.inputs.create({
   url: "https://samples.clarifai.com/puppy.jpg",
@@ -1279,6 +1435,9 @@ app.inputs.create({
 );
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, Geo, GeoPoint
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1288,11 +1447,17 @@ geo_p1 = Geo(geo_point=GeoPoint(116.2317,39.5427))
 app.inputs.create_image_from_url(url="https://samples.clarifai.com/puppy.jpg", geo=geo_p1)
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 client.addInputs().plus(ClarifaiInput.forImage("https://samples.clarifai.com/puppy.jpg")
     .withGeo(PointF.at(116.2317F, 39.5427F))).executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1319,6 +1484,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/metro-north.jpg"];
 image.location = [[ClarifaiLocation alloc] initWithLatitude:116.2317 longitude:39.5427];
@@ -1329,6 +1497,9 @@ image.location = [[ClarifaiLocation alloc] initWithLatitude:116.2317 longitude:3
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\GeoPoint;
@@ -1351,6 +1522,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -1378,6 +1552,8 @@ curl -X POST \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1385,6 +1561,8 @@ curl -X POST \
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.inputs.search({
   input: {
@@ -1405,6 +1583,9 @@ app.inputs.search({
 );
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, GeoPoint, GeoLimit
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1415,6 +1596,9 @@ geo_l = GeoLimit(limit_type='kilometer', limit_range=1)
 imgs = app.inputs.search_by_geo(geo_point=geo_p, geo_limit=geo_l)
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 client.searchInputs(SearchClause.matchGeo(PointF.at(59F, 29.75F), Radius.of(500, Radius.Unit.KILOMETER)))
             .getPage(1)
@@ -1422,6 +1606,9 @@ client.searchInputs(SearchClause.matchGeo(PointF.at(59F, 29.75F), Radius.of(500,
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1449,6 +1636,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiLocation *loc = [[ClarifaiLocation alloc] initWithLatitude:116.2317 longitude:39.5427];
@@ -1464,6 +1654,9 @@ ClarifaiSearchTerm *term = [ClarifaiSearchTerm searchInputsWithGeoFilter:geoFilt
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\GeoPoint;
@@ -1497,6 +1690,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -1528,6 +1724,8 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1535,6 +1733,8 @@ curl -X POST \
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.inputs.search({
   input: {
@@ -1556,6 +1756,9 @@ app.inputs.search({
 );
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, GeoBox, GeoPoint
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1567,12 +1770,18 @@ box1 = GeoBox(point1=p1, point2=p2)
 imgs = app.inputs.search_by_geo(geo_box=box1)
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 client.searchInputs(SearchClause.matchGeo(PointF.at(3F, 0F), PointF.at(70, 30F)))
             .getPage(1)
             .executeSync()
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1600,6 +1809,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiLocation *startLoc = [[ClarifaiLocation alloc] initWithLatitude:50 longitude:58];
@@ -1614,6 +1826,9 @@ ClarifaiGeo *geoBox = [[ClarifaiGeo alloc] initWithGeoBoxFromStartLocation:start
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\GeoPoint;
@@ -1643,6 +1858,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -1657,7 +1875,7 @@ curl -X POST \
             "data": {
               "geo": {
                 "geo_box": [
-                  {  
+                  {
                     "geo_point": {
                       "latitude": 35,
                       "longitude": -30
@@ -1680,6 +1898,8 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1689,6 +1909,8 @@ You can also combine searches using AND.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.search([
@@ -1706,6 +1928,9 @@ app.inputs.search([
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, InputSearchTerm, OutputSearchTerm, SearchQueryBuilder
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1723,6 +1948,9 @@ app.inputs.search(query)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.searchInputs()
@@ -1736,6 +1964,9 @@ client.searchInputs()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1762,6 +1993,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 //Search for inputs that are predicted as "fast" and visually similar to the given image.
@@ -1778,6 +2012,9 @@ ClarifaiSearchTerm *term2 = [ClarifaiSearchTerm searchVisuallyWithImageURL:@"htt
 }];
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Searches\SearchBy;
@@ -1809,6 +2046,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -1844,5 +2084,5 @@ curl -X POST \
 https://api.clarifai.com/v2/searches
 
 ```
-
-
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/android.md
+++ b/android.md
@@ -68,16 +68,24 @@ The Clarifai SDK is initialized by calling `Clarifai.start(applicationContext, a
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 import com.clarifai.clarifai_android_sdk.core.Clarifai;
 
@@ -105,15 +113,38 @@ class MainActivity : AppCompatActivity() {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Android SDK
+
+```
+{% endcode-tabs-item %}
+
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Only for the Android SDK
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=php %}
+```php
+// Only for the Android SDK
+
+```
+
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 // Only for the Android SDK
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -126,16 +157,24 @@ All inputs are created from a DataAsset object in the Android SDK. A Data Asset 
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 import com.clarifai.clarifai_android_sdk.dataassets.DataAsset;
 import com.clarifai.clarifai_android_sdk.dataassets.Image;
@@ -179,34 +218,64 @@ val dataAsset = DataAsset(imageFromBitmap)
 val input = Input(dataAsset)
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Android SDK
+
+```
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Only for the Android SDK
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=php %}
+```php
+// Only for the Android SDK
+
+```
+
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 // Only for the Android SDK
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
 ### Load Models On Device
 
-Clarifai has a variety of Pre-Built Models to predict against. However, only the `General Model` is readily available within the SDK. For access to other models please contact sales@clarifai.com. The sample code below shows how to load the `General Model` and make a prediction against it.  
+Clarifai has a variety of Pre-Built Models to predict against. However, only the `General Model` is readily available within the SDK. For access to other models please contact sales@clarifai.com. The sample code below shows how to load the `General Model` and make a prediction against it.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 import com.clarifai.clarifai_android_sdk.datamodels.Model;
 ...
@@ -223,15 +292,37 @@ import com.clarifai.clarifai_android_sdk.datamodels.Model
 val model = Clarifai.getInstance().generalModel
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Android SDK
+
+```
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Only for the Android SDK
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=php %}
+```php
+// Only for the Android SDK
+
+```
+
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 // Only for the Android SDK
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -240,22 +331,30 @@ val model = Clarifai.getInstance().generalModel
 Just as with our API, you can use the predict functionality on device with any of our available Pre-Built Models. Predictions generate outputs. An output has a similar structure to an input. It contains a data asset and concepts. The concepts associated with an output contain the predictions and their respective score (degree of confidence).
 
 
-Note that the prediction results from pre-built models on the SDK may differ from those on the API. Specifically, there may be a loss of accuracy up to 5% due to the conversion of the models that allow them to be compact enough to be used on lightweight devices. This loss is expected within the current industry standards. 
+Note that the prediction results from pre-built models on the SDK may differ from those on the API. Specifically, there may be a loss of accuracy up to 5% due to the conversion of the models that allow them to be compact enough to be used on lightweight devices. This loss is expected within the current industry standards.
 
 
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 import com.clarifai.clarifai_android_sdk.datamodels.Input;
 import com.clarifai.clarifai_android_sdk.datamodels.Model;
@@ -313,15 +412,34 @@ model.predict(object: Model.ModelCallbacks() {
 });
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Android SDK
+
+```
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Only for the Android SDK
 
 ```
+{% endcode-tabs-item %}
 
-```cURL
+{% code-tabs-item title=php %}
+```php
 // Only for the Android SDK
 
 ```
 
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=cURL %}
+```cURL
+// Only for the Android SDK
 
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/authentication.md
+++ b/authentication.md
@@ -33,13 +33,13 @@ Note: API Keys do not expire. In case your API Key gets compromised, you should 
 After creating your `API Key`, you are ready to make API calls. If you are using a client, authentication will be handled for you. If you are using the REST API, you will need to add the `Authorization` header as described in the cURL example.
 
 {% code-tabs %}
-{% code-tabs-item title="Javascript" %}
-```javascript
+{% code-tabs-item title="js" %}
+```js
 const app = new Clarifai.App({apiKey: 'YOUR_API_KEY'});
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="Python" %}
+{% code-tabs-item title="python" %}
 ```python
 from clarifai.rest import ClarifaiApp
 
@@ -47,13 +47,13 @@ app = ClarifaiApp(api_key='YOUR_API_KEY')
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
+{% code-tabs-item title=java %}
 ```java
 new ClarifaiBuilder("YOUR_API_KEY").buildSync();
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
+{% code-tabs-item title=csharp %}
 ```csharp
 using System.Threading.Tasks;
 using Clarifai.API;
@@ -71,14 +71,14 @@ namespace YourNamespace
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
-```objectivec
+{% code-tabs-item title=objective-c %}
+```objective-c
 ClarifaiApp *app = [[ClarifaiApp alloc] initWithApiKey:@"YOUR_API_KEY"];
 
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 
@@ -86,8 +86,8 @@ $client = new ClarifaiClient('YOUR_API_KEY');
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
-```bash
+{% code-tabs-item title=cURL %}
+```cURL
 curl -X POST \
   -H 'Authorization: Key YOUR_API_KEY' \
   -H "Content-Type: application/json" \
@@ -99,4 +99,3 @@ curl -X POST \
 
 
 If the API Key does not have the required scope\(s\), you will receive one of the following responses: 1. Rejected Request: if a large portion of the response requires a scope that is missing 2. Redacted Response: if majority of the response has the required scope\(s\), a small portion of the response will be redacted to not reveal unwarranted information
-

--- a/clients.md
+++ b/clients.md
@@ -135,7 +135,7 @@ namespace YourNamespace
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="objectivec" %}
+{% code-tabs-item title="objective-c" %}
 ```objective-c
 
 // Installation via CocoaPods - https://cocoapods.org

--- a/feedback.md
+++ b/feedback.md
@@ -35,6 +35,8 @@ Note that the `event_type` should be set to `annotation`.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.models.feedback(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/dog.tiff', {
   id: '{input_id}',
@@ -59,6 +61,9 @@ app.models.feedback(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/dog.ti
   });
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, FeedbackInfo
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -66,16 +71,19 @@ app = ClarifaiApp(api_key='YOUR_API_KEY')
 model = app.models.get('general-v1.3')
 
 model.send_concept_feedback(
-    input_id='{input_id}', 
-    url='https://samples.clarifai.com/dog.tiff', 
-    concepts=['ai_8S2Vq3cR'], 
-    not_concepts=['ai_mFqxrph2'], 
-    feedback_info=FeedbackInfo(event_type='annotation', 
-                               output_id='{output_id}', 
-                               end_user_id='{end_user_id}', 
+    input_id='{input_id}',
+    url='https://samples.clarifai.com/dog.tiff',
+    concepts=['ai_8S2Vq3cR'],
+    not_concepts=['ai_mFqxrph2'],
+    feedback_info=FeedbackInfo(event_type='annotation',
+                               output_id='{output_id}',
+                               end_user_id='{end_user_id}',
                                session_id='{session_id}'))
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 ModelFeedbackRequest request =
     client.modelFeedback(client.getDefaultModels().generalModel().id())
@@ -91,6 +99,9 @@ ModelFeedbackRequest request =
        .withSessionId("{session_id}");
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -126,10 +137,16 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Coming Soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -161,6 +178,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
@@ -188,10 +208,14 @@ curl -X POST \
   }'\
   https://api.clarifai.com/v2/models/aaa03c23b3724a16a56b629203edc62c/feedback
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
     "status": {
         "code": 10000,
@@ -199,6 +223,8 @@ curl -X POST \
     }
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### Prediction with Regions Feedback
 To send feedback on predictions, you can use `POST /v2/models/{model_id}/feedback`.
@@ -216,6 +242,8 @@ Note that the `event_type` should be set to `annotation`.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.models.feedback(Clarifai.LOGO_MODEL, 'https://clarifai.com/images/model-samples/logo-002.jpg', {
   id: '{input_id}',
@@ -254,6 +282,9 @@ app.models.feedback(Clarifai.LOGO_MODEL, 'https://clarifai.com/images/model-samp
   });
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, Region, RegionInfo, BoundingBox, Concept, FeedbackInfo
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -274,6 +305,9 @@ model.send_region_feedback(
                                session_id='{session_id}'))
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 ModelFeedbackRequest request =
     client.modelFeedback(client.getDefaultModels().logoModel().id())
@@ -291,6 +325,9 @@ ModelFeedbackRequest request =
         .withSessionId("{session_id}");
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -332,10 +369,16 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Coming Soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -375,6 +418,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
@@ -389,7 +435,7 @@ curl -X POST \
         },
         "regions":
         [
-          {   
+          {
             "region_info": {
               "bounding_box": {
                 "top_row": 0.3,
@@ -417,10 +463,14 @@ curl -X POST \
   }'\
   https://api.clarifai.com/v2/models/c443119bf2ed4da98487520d01a0b1e3/feedback
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
     "status": {
         "code": 10000,
@@ -428,6 +478,8 @@ curl -X POST \
     }
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### Search Feedback
 To send feedback on searches, you can use `POST /v2/searches/feedback`.
@@ -444,6 +496,8 @@ Note that the `event_type` should be set to `search_click`.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.inputs.searchFeedback('{input_id}', '{search_id}', '{end_user_id}', '{session_id}')
   .then(response => {
@@ -454,6 +508,9 @@ app.inputs.searchFeedback('{input_id}', '{search_id}', '{end_user_id}', '{sessio
   });
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp, FeedbackInfo
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -463,6 +520,9 @@ app.inputs.send_search_feedback(
     FeedbackInfo('{end_user_id}', '{session_id}', 'search_click', search_id='{search_id}'))
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 SearchesFeedbackRequest request = client.searchesFeedback()
     .withId("{input_id}")
@@ -472,6 +532,9 @@ SearchesFeedbackRequest request = client.searchesFeedback()
     .withSearchId("{search_id}");
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -497,10 +560,16 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Coming Soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -521,6 +590,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
@@ -539,10 +611,14 @@ curl -X POST \
   }'\
   https://api.clarifai.com/v2/searches/feedback
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
     "status": {
         "code": 10000,
@@ -550,3 +626,5 @@ curl -X POST \
     }
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/inputs.md
+++ b/inputs.md
@@ -20,6 +20,8 @@ database. If you do not send an `id`, one will be created for you.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.create({
@@ -35,6 +37,9 @@ app.inputs.create({
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -43,6 +48,9 @@ app.inputs.create_image_from_url("https://samples.clarifai.com/metro-north.jpg")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.addInputs()
@@ -51,6 +59,9 @@ client.addInputs()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -74,6 +85,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/metro-north.jpg"];
@@ -83,6 +97,9 @@ ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clar
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -105,6 +122,9 @@ if ($response->isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -125,6 +145,8 @@ curl -X POST \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -136,6 +158,8 @@ the `url` parameter.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.create({
@@ -151,6 +175,9 @@ app.inputs.create({
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -163,6 +190,9 @@ app.inputs.create_image_from_base64(base64_bytes)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.addInputs()
@@ -171,6 +201,9 @@ client.addInputs()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.IO;
@@ -195,6 +228,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *imageFromImage = [[ClarifaiImage alloc] initWithImage:@"dress.jpg"];
@@ -204,6 +240,9 @@ ClarifaiImage *imageFromImage = [[ClarifaiImage alloc] initWithImage:@"dress.jpg
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiFileImage;
@@ -224,6 +263,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -244,6 +286,8 @@ curl -X POST \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -252,6 +296,8 @@ curl -X POST \
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.create([
@@ -274,6 +320,9 @@ app.inputs.create([
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 from clarifai.rest import Image as ClImage
@@ -287,6 +336,9 @@ app.inputs.bulk_create_images([img1, img2])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.addInputs()
@@ -299,6 +351,9 @@ client.addInputs()
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -329,6 +384,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *train = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/metro-north.jpg"];
@@ -343,6 +401,9 @@ puppy.inputID = @"puppy";
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiURLImage;
@@ -368,6 +429,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -397,6 +461,8 @@ curl -X POST \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -414,6 +480,8 @@ You can add inputs with concepts as either a URL or bytes.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.create({
@@ -435,6 +503,9 @@ app.inputs.create({
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 from clarifai.rest import Image as ClImage
@@ -460,6 +531,9 @@ img2 = ClImage(url="https://samples.clarifai.com/wedding.jpg", concepts=['our_we
 app.inputs.bulk_create_images([img1, img2])
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.addInputs()
@@ -472,6 +546,9 @@ client.addInputs()
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -500,6 +577,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *puppy = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/puppy.jpg"
@@ -511,6 +591,9 @@ ClarifaiImage *puppy = [[ClarifaiImage alloc] initWithURL:@"https://samples.clar
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiURLImage;
@@ -533,6 +616,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -559,6 +645,8 @@ curl -X POST \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -571,6 +659,8 @@ arbitrary JSON.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.create({
@@ -587,6 +677,9 @@ app.inputs.create({
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 from clarifai.rest import Image as ClImage
@@ -607,6 +700,9 @@ app.inputs.bulk_create_images([img])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 final JsonObject metadata = new JsonObject();
@@ -618,6 +714,9 @@ client.addInputs()
     ).executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -647,6 +746,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *puppy = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/puppy.jpg"
@@ -658,10 +760,16 @@ puppy.metadata = @{@"my_key": @[@"my",@"values"], @"cuteness": @"extra-cute"};
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 //coming soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -687,6 +795,8 @@ curl -X POST \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -703,6 +813,8 @@ original left edge.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.create(
@@ -721,6 +833,9 @@ app.inputs.create(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -730,6 +845,9 @@ app.inputs.create_image_from_url(url="https://samples.clarifai.com/metro-north.j
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.addInputs()
@@ -747,6 +865,9 @@ client.addInputs()
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -773,6 +894,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiCrop *crop = [[ClarifaiCrop alloc] initWithTop:0.2 left:0.3 bottom:0.7 right:0.8];
@@ -784,6 +908,9 @@ ClarifaiImage *puppy = [[ClarifaiImage alloc] initWithURL:@"https://samples.clar
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Crop;
@@ -806,6 +933,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -827,6 +957,8 @@ curl -X POST \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -842,6 +974,8 @@ This request is paginated.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.list({page: 1, perPage: 20}).then(
@@ -855,6 +989,9 @@ app.inputs.list({page: 1, perPage: 20}).then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -867,6 +1004,9 @@ app.inputs.get_by_page(page=1, per_page=20)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getInputs() // optionally takes a perPage parameter
@@ -874,6 +1014,9 @@ client.getInputs() // optionally takes a perPage parameter
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -896,6 +1039,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app getInputsOnPage:1 pageSize:20 completion:^(NSArray<ClarifaiInput *> *inputs, NSError *error) {
@@ -904,6 +1050,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiInput;
@@ -925,6 +1074,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -932,6 +1084,8 @@ curl -X GET \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -941,6 +1095,8 @@ If you'd like to get a specific input by id, you can do that as well.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.get({id}).then(
@@ -954,6 +1110,9 @@ app.inputs.get({id}).then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -962,11 +1121,17 @@ image = app.inputs.get(input_id)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getInputByID("{id}").executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -988,6 +1153,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app getInput:input_id completion:^(ClarifaiInput *input, NSError *error) {
@@ -996,6 +1164,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiURLImage;
@@ -1016,6 +1187,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -1023,6 +1197,8 @@ curl -X GET \
   https://api.clarifai.com/v2/inputs/{id}
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1034,6 +1210,8 @@ If you add inputs in bulk, they will process in the background. You can get the 
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.getStatus().then(
@@ -1047,6 +1225,9 @@ app.inputs.getStatus().then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1055,11 +1236,17 @@ app.inputs.check_status()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getInputsStatus().executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1081,6 +1268,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app getInputsStatus:^(int numProcessed, int numToProcess, int errors, NSError *error) {
@@ -1089,6 +1279,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiInputsStatus;
@@ -1111,6 +1304,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -1118,6 +1314,8 @@ curl -X GET \
   https://api.clarifai.com/v2/inputs/status
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1129,6 +1327,8 @@ To update an input with a new concept, or to change a concept value from true/fa
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.mergeConcepts([
@@ -1168,6 +1368,9 @@ app.inputs.get({id}).then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1176,6 +1379,9 @@ app.inputs.merge_concepts('{id}', concepts=['tree'], not_concepts=['water'])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.mergeConceptsForInput("{input_id}")
@@ -1186,6 +1392,9 @@ client.mergeConceptsForInput("{input_id}")
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -1214,6 +1423,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"cute cat"];
@@ -1223,6 +1435,9 @@ ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"cute c
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ModifyAction;
@@ -1245,6 +1460,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X PATCH \
@@ -1274,6 +1492,8 @@ curl -X PATCH \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1283,6 +1503,8 @@ To remove concepts that were already added to an input, you can do this:
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.deleteConcepts([
@@ -1322,6 +1544,9 @@ app.inputs.get({id}).then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1330,6 +1555,9 @@ app.inputs.delete_concepts({id}, concepts=['tree', 'water'])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.removeConceptsForInput("{input_id}")
@@ -1340,6 +1568,9 @@ client.removeConceptsForInput("{input_id}")
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -1368,6 +1599,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"cute cat"];
@@ -1377,6 +1611,9 @@ ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"cute c
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ModifyAction;
@@ -1399,6 +1636,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X PATCH \
@@ -1422,6 +1662,8 @@ curl -X PATCH \
   https://api.clarifai.com/v2/inputs/
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1434,6 +1676,8 @@ its already been added.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.mergeConcepts([
@@ -1475,6 +1719,9 @@ app.inputs.mergeConcepts([
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1488,18 +1735,27 @@ app.inputs.bulk_merge_concepts(input_ids, concept_pairs)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 // Coming soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 // Coming soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 ClarifaiConcept *newConcept = [[ClarifaiConcept alloc] initWithConceptID:@"tree"];
 [_app getInput:@"{input_id}" completion:^(ClarifaiInput *input, NSError *error) {
@@ -1516,12 +1772,18 @@ ClarifaiConcept *newConcept = [[ClarifaiConcept alloc] initWithConceptID:@"tree"
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 //coming soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X PATCH \
@@ -1566,6 +1828,8 @@ curl -X PATCH \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1575,6 +1839,8 @@ You can bulk delete multiple concepts from a list of inputs:
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.deleteConcepts([
@@ -1603,6 +1869,9 @@ app.inputs.deleteConcepts([
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1616,18 +1885,27 @@ app.inputs.bulk_delete_concepts(input_ids, concept_pairs)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 // Coming soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 // Coming soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"cute cat"];
@@ -1637,10 +1915,16 @@ ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"cute c
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 // Coming soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X PATCH \
@@ -1681,6 +1965,8 @@ curl -X PATCH \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1690,6 +1976,8 @@ You can delete a single input by id:
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.delete(INPUT_ID).then(
@@ -1703,6 +1991,9 @@ app.inputs.delete(INPUT_ID).then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1711,12 +2002,18 @@ app.inputs.delete("INPUT_ID")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.deleteInput("INPUT_ID")
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1738,6 +2035,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app deleteInputsByIDList:@[INPUT_ID] completion:^(NSError *error) {
@@ -1746,6 +2046,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 
@@ -1764,6 +2067,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X DELETE \
@@ -1771,6 +2077,8 @@ curl -X DELETE \
   https://api.clarifai.com/v2/inputs/<INPUT_ID>
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1780,6 +2088,8 @@ You can also delete multiple inputs in one API call. This will happen asynchrono
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.delete([{id1}, {id2}]).then(
@@ -1793,6 +2103,9 @@ app.inputs.delete([{id1}, {id2}]).then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1801,6 +2114,9 @@ app.delete(["{id1}", "{id2}"])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.deleteInputsBatch()
@@ -1808,6 +2124,9 @@ client.deleteInputsBatch()
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1829,6 +2148,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app deleteInputsByIDList:@[{id1}, {id2}] completion:^(NSError *error) {
@@ -1837,6 +2159,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -1857,6 +2182,9 @@ if ($response->isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X DELETE \
@@ -1869,6 +2197,8 @@ curl -X DELETE \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1879,6 +2209,8 @@ that as well. This will happen asynchronously.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.delete().then(
@@ -1892,6 +2224,9 @@ app.inputs.delete().then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1900,12 +2235,18 @@ app.inputs.delete_all()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.deleteAllInputs().executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1927,6 +2268,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app deleteAllInputs:^(ClarifaiInput *input, NSError *error) {
@@ -1935,6 +2279,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -1956,6 +2303,9 @@ if ($response->isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X DELETE \
@@ -1968,5 +2318,5 @@ curl -X DELETE \
   https://api.clarifai.com/v2/inputs
 
 ```
-
-
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/languages.md
+++ b/languages.md
@@ -53,6 +53,8 @@ language. Here is how you predict concepts in Chinese:
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.predict(Clarifai.GENERAL_MODEL, "https://samples.clarifai.com/metro-north.jpg", {language: 'zh'}).then(
@@ -66,6 +68,9 @@ app.models.predict(Clarifai.GENERAL_MODEL, "https://samples.clarifai.com/metro-n
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -80,6 +85,9 @@ m.predict_by_url('https://samples.clarifai.com/metro-north.jpg', lang='ja')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.predict(client.getDefaultModels().generalModel().id())
@@ -89,6 +97,9 @@ client.predict(client.getDefaultModels().generalModel().id())
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -115,6 +126,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 // first get the general model.
@@ -133,6 +147,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -153,7 +170,7 @@ if ($response-> isSuccessful()) {
     $output = $response->get();
 
     echo "Predicted concepts:\n";
-    
+
     foreach ($output->data() as $concept) {
         echo $concept->name() . ': ' . $concept->value() . "\n";
     }
@@ -166,6 +183,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -193,10 +213,14 @@ curl -X POST \
   https://api.clarifai.com/v2/models/aaa03c23b3724a16a56b629203edc62c/outputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -364,6 +388,8 @@ curl -X POST \
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 #### Example Search By Tag API Request
 
@@ -373,6 +399,8 @@ searching for '人' which is simplified Chinese for 'people'.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.search({
@@ -391,6 +419,9 @@ app.inputs.search({
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 
@@ -401,6 +432,9 @@ app.inputs.search_by_predicted_concepts(u'人', lang='zh')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.searchInputs(
@@ -411,6 +445,9 @@ client.searchInputs(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -440,6 +477,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 // create search term with concept you want to search predicted inputs with.
@@ -457,6 +497,9 @@ ClarifaiSearchTerm *searchTerm = [[ClarifaiSearchTerm alloc] initWithSearchItem:
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -487,6 +530,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -514,6 +560,8 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -524,6 +572,8 @@ You can also search for concepts in a different language:
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.concepts.search('人*', 'zh').then(
@@ -537,6 +587,9 @@ app.concepts.search('人*', 'zh').then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 
@@ -545,6 +598,9 @@ app.concepts.search(u'人*', lang='zh')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.searchConcepts("人*")
@@ -554,6 +610,9 @@ client.searchConcepts("人*")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -578,6 +637,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 // Search for all concept names in chinese, beginning with "人".
@@ -590,6 +652,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -618,6 +683,9 @@ if ($response->isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -633,10 +701,14 @@ curl -X POST \
   https://api.clarifai.com/v2/concepts/searches
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -806,3 +878,5 @@ curl -X POST \
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/mobile.md
+++ b/mobile.md
@@ -20,21 +20,39 @@ The Clarifai SDK is initialized by calling the `startWithApiKey` method. We reco
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Apple SDK
+
+```
+{% endcode-tabs-item %}
+
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 @import Clarifai_Apple_SDK;
 
@@ -45,11 +63,25 @@ The Clarifai SDK is initialized by calling the `startWithApiKey` method. We reco
 }
 
 ```
+{% endcode-tabs-item %}
 
+
+{% code-tabs-item title=php %}
+```php
+// Only for the Apple SDK
+
+```
+
+
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -65,21 +97,39 @@ All inputs are created from a DataAsset object in the Apple SDK. A Data Asset is
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Apple SDK
+
+```
+{% endcode-tabs-item %}
+
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Initialize CAIImage object from an image URL
 NSURL *imageURL = [NSURL urlWithString:@"<your image url>"];
@@ -98,11 +148,24 @@ CAIDataAsset *dataAsset = [[CAIDataAsset alloc] initWithImage:image];
 CAIInput *input = [[CAIInput alloc] initWithDataAsset:dataAsset];
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=php %}
+```php
+// Only for the Apple SDK
+
+```
+
+
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -112,21 +175,39 @@ After creating Inputs, it is also possible to save them in the SDK for later use
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Apple SDK
+
+```
+{% endcode-tabs-item %}
+
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Saving an input
 [[Clarifai sharedInstance] saveEntities:@[input]];
@@ -142,11 +223,23 @@ After creating Inputs, it is also possible to save them in the SDK for later use
         }];
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=php %}
+```php
+// Only for the Apple SDK
+
+```
+
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -159,21 +252,39 @@ Note that the prediction results from pre-built models on the SDK may differ fro
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Apple SDK
+
+```
+{% endcode-tabs-item %}
+
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // See how to create an input from the examples above
 CAIInput *input = [[CAIInput alloc] initWithDataAsset:dataAsset];
@@ -187,11 +298,23 @@ CAIModel *generalModel = [Clarifai sharedInstance].generalModel;
 }];
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=php %}
+```php
+// Only for the Apple SDK
+
+```
+
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -201,21 +324,39 @@ Our team has developed a variety of pre-trained public models which our users ca
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 // Only for the Apple SDK
 
 ```
+{% endcode-tabs-item %}
 
+{% code-tabs-item title=csharp %}
+```csharp
+// Only for the Apple SDK
+
+```
+{% endcode-tabs-item %}
+
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Get the General Model
 CAIModel *generalModel = [Clarifai sharedInstance].generalModel;
@@ -243,9 +384,20 @@ CAIModel *generalModel = [Clarifai sharedInstance].generalModel;
         }];
 
 ```
+{% endcode-tabs-item %}
 
-```cURL
+{% code-tabs-item title=php %}
+```php
 // Only for the Apple SDK
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
+```cURL
+// Only for the Apple SDK
+
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/models.md
+++ b/models.md
@@ -11,6 +11,8 @@ When you create a model you give it a name and an id. If you don't supply an id,
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.create("petsID").then(
@@ -24,6 +26,9 @@ app.models.create("petsID").then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -32,12 +37,18 @@ app.models.create('petsID')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.createModel("petsID").executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -59,6 +70,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app createModel:nil name:@"petsModel" modelID:@"petsID" conceptsMutuallyExclusive:NO closedEnvironment:NO completion:^(ClarifaiModel *model, NSError *error) {
@@ -67,6 +81,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 
@@ -85,6 +102,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -99,6 +119,8 @@ curl -X POST \
   https://api.clarifai.com/v2/models
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -112,6 +134,8 @@ remove concepts later.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.create(
@@ -130,6 +154,9 @@ app.models.create(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -138,6 +165,9 @@ model = app.models.create('petsID', concepts=['boscoe'])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.createModel("petsID")
@@ -148,6 +178,9 @@ client.createModel("petsID")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -173,6 +206,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app createModel:@[@"cat", @"dog"] name:@"petsModel" modelID:@"petsID" conceptsMutuallyExclusive:NO closedEnvironment:NO completion:^(ClarifaiModel *model, NSError *error) {
@@ -181,6 +217,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Predictions\Concept;
@@ -201,6 +240,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -228,6 +270,8 @@ curl -X POST \
   https://api.clarifai.com/v2/models
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -239,6 +283,8 @@ model.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.initModel({model_id}).then(function(model) {
@@ -261,6 +307,9 @@ function updateModel(model) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -270,6 +319,9 @@ model.add_concepts(['boscoe'])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.modifyModel("{{model_id}}")
@@ -284,6 +336,9 @@ model.modify()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -321,6 +376,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"dress"];
@@ -330,6 +388,9 @@ ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"dress"
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ModifyAction;
@@ -353,6 +414,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X PATCH \
@@ -379,6 +443,8 @@ curl -X PATCH \
   https://api.clarifai.com/v2/models/
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -389,6 +455,8 @@ Conversely, if you'd like to remove concepts from a model, you can also do that.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.initModel({model_id}).then(function(model) {
@@ -411,6 +479,9 @@ function updateModel(model) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -420,6 +491,9 @@ model.delete_concepts(['boscoe'])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.modifyModel("{{model_id}}")
@@ -434,6 +508,9 @@ model.modify()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -472,6 +549,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"dress"];
@@ -481,6 +561,9 @@ ClarifaiConcept *concept = [[ClarifaiConcept alloc] initWithConceptName:@"dress"
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -506,6 +589,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X PATCH \
@@ -532,6 +618,8 @@ curl -X PATCH \
   https://api.clarifai.com/v2/models/
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -540,11 +628,16 @@ curl -X PATCH \
 The code below showcases how to update a concept's name given its id.
 
 
- 
+
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 ** Coming Soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -553,12 +646,18 @@ app.concepts.update(concept_id='concept_id', concept_name='new_concept_name')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 ** Coming Soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -582,12 +681,18 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ** Coming Soon
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Predictions\Concept;
@@ -608,6 +713,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X PATCH \
@@ -626,6 +734,8 @@ curl -X PATCH \
   https://api.clarifai.com/v2/concepts
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -636,6 +746,8 @@ Here we will change the model name to 'newname' and the model's configuration to
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.initModel({model_id}).then(
@@ -656,6 +768,9 @@ function updateModel(model) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -678,6 +793,9 @@ model.update(model_name="newname",
              concepts=["birds", "hurd"])
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.modifyModel("{{model_id}}")
@@ -688,6 +806,9 @@ client.modifyModel("{{model_id}}")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -713,6 +834,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app updateModel:@"{model_id}" name:@"newName" conceptsMutuallyExclusive:NO closedEnvironment:NO completion:^(ClarifaiModel *model, NSError *error) {
@@ -721,6 +845,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 
@@ -743,6 +870,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X PATCH \
@@ -767,6 +897,8 @@ curl -X PATCH \
   https://api.clarifai.com/v2/models/
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -780,6 +912,8 @@ To get a list of all models including models you've created as well as
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.list().then(
@@ -793,6 +927,9 @@ app.models.list().then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -802,12 +939,18 @@ app.models.get_all()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getModels().getPage(1).executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -830,6 +973,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app getModels:1 resultsPerPage:30 completion:^(NSArray<ClarifaiModel *> *models, NSError *error) {
@@ -838,6 +984,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Models\Model;
@@ -862,6 +1011,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -869,6 +1021,8 @@ curl -X GET \
   https://api.clarifai.com/v2/models
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -879,6 +1033,8 @@ All models have unique Ids. You can get a specific model by its id:
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.get({model_id}).then(
@@ -892,6 +1048,9 @@ app.models.get({model_id}).then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -904,12 +1063,18 @@ model = app.models.get('my_model1')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getModelByID("{model_id}").executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -933,6 +1098,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app getModel:@"model_id" completion:^(ClarifaiModel *model, NSError *error) {
@@ -941,6 +1109,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Models\Model;
@@ -966,6 +1137,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -973,6 +1147,8 @@ curl -X GET \
   https://api.clarifai.com/v2/models/{model_id}
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -982,6 +1158,8 @@ The output info of a model lists what concepts it contains.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.initModel({model_id}).then(
@@ -1002,6 +1180,9 @@ function getModelOutputInfo(model) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1011,12 +1192,18 @@ model.get_info(verbose=True)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getModelByID("{model_id}").executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1042,6 +1229,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app getModelByID:@"{model_id}" completion:^(ClarifaiModel *model, NSError *error) {
@@ -1050,6 +1240,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -1081,6 +1274,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -1088,6 +1284,8 @@ curl -X GET \
   https://api.clarifai.com/v2/models/{model_id}/output_info
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1097,6 +1295,8 @@ Every time you train a model, it creates a new version. You can list all the ver
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.initModel('{id}').then(
@@ -1117,6 +1317,9 @@ app.models.initModel('{id}').then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1126,12 +1329,18 @@ model.list_versions()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getModelVersions("{model_id}").getPage(1).executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1153,6 +1362,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app listVersionsForModel:@"{model_id}" page:1 resultsPerPage:30 completion:^(NSArray<ClarifaiModelVersion *> *versions, NSError *error) {
@@ -1161,6 +1373,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -1190,6 +1405,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -1197,6 +1415,8 @@ curl -X GET \
   https://api.clarifai.com/v2/models/{model_id}/versions
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1207,6 +1427,8 @@ model version status to determine if your model is trained or still training.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.initModel('{id}').then(
@@ -1227,6 +1449,9 @@ app.models.initModel('{id}').then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1236,6 +1461,9 @@ model.get_version('{version_id}')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getModelVersionByID("{model_id}", "{version_id}").executeSync();
@@ -1247,6 +1475,9 @@ client.getModelByID("{model_id}")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1268,6 +1499,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app getVersionForModel:@"{model_id}" versionID:{version_id} completion:^(ClarifaiModelVersion *version, NSError *error) {
@@ -1276,6 +1510,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Models\ModelVersion;
@@ -1301,6 +1538,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -1308,6 +1548,8 @@ curl -X GET \
   https://api.clarifai.com/v2/models/{model_id}/versions/{version_id}
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1317,6 +1559,8 @@ You can list all the inputs that were used to train the model.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.initModel('{id}').then(
@@ -1337,6 +1581,9 @@ app.models.initModel('{id}').then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1346,12 +1593,18 @@ model.get_inputs()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getModelInputs("{model_id}").getPage(1).executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1374,6 +1627,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app listTrainingInputsForModel:@"{model_id}" page:1 resultsPerPage:30 completion:^(NSArray<ClarifaiInput *> *inputs, NSError *error) {
@@ -1382,11 +1638,17 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 // Coming soon
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -1394,6 +1656,8 @@ curl -X GET \
   https://api.clarifai.com/v2/models/{model_id}/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1403,6 +1667,8 @@ You can also list all the inputs that were used to train a specific model versio
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.initModel({id: '{model_id}', version: '{version_id}'}).then(
@@ -1423,6 +1689,9 @@ app.models.initModel({id: '{model_id}', version: '{version_id}'}).then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1432,6 +1701,9 @@ model.get_inputs('{version_id}')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getModelInputs("{model_id}")
@@ -1441,6 +1713,9 @@ client.getModelInputs("{model_id}")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1463,6 +1738,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app listTrainingInputsForModel:@"{model_id}" page:1 resultsPerPage:30 completion:^(NSArray<ClarifaiInput *> *inputs, NSError *error) {
@@ -1471,11 +1749,17 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 // Coming soon
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -1483,6 +1767,8 @@ curl -X GET \
   https://api.clarifai.com/v2/models/{model_id}/versions/{version_id}/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1492,6 +1778,8 @@ You can delete a model using the model_id.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.delete('{id}').then(
@@ -1505,6 +1793,9 @@ app.models.delete('{id}').then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1513,12 +1804,18 @@ app.models.delete('{id}')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.deleteModel("{model_id}").executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1540,6 +1837,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app deleteModel:@"{model_id}" completion:^(NSError *error) {
@@ -1548,6 +1848,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 
@@ -1567,6 +1870,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X DELETE \
@@ -1574,6 +1880,8 @@ curl -X DELETE \
   https://api.clarifai.com/v2/models/{model_id}
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1583,6 +1891,8 @@ You can also delete a specific version of a model with the model_id and version_
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.delete('{model_id}', '{version_id}').then(
@@ -1596,6 +1906,9 @@ app.models.delete('{model_id}', '{version_id}').then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1609,6 +1922,9 @@ model.delete_version('{version_id}')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.deleteModelVersion("{model_id}", "{version_id}").executeSync();
@@ -1621,6 +1937,9 @@ client.getModelByID("{model_id}")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1648,6 +1967,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app deleteVersionForModel:{model_id} versionID:{version_id} completion:^(NSError *error) {
@@ -1656,6 +1978,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 
@@ -1675,6 +2000,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X DELETE \
@@ -1682,6 +2010,8 @@ curl -X DELETE \
   https://api.clarifai.com/v2/models/{model_id}/versions/{version_id}
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1692,6 +2022,8 @@ with caution as these cannot be recovered.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.delete().then(
@@ -1705,6 +2037,9 @@ app.models.delete().then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1713,12 +2048,18 @@ app.models.delete_all()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.deleteAllModels().executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1740,6 +2081,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [_app deleteAllModels:^(NSError *error) {
@@ -1748,6 +2092,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use ClarifaiIntTests\BaseIntTest;
@@ -1768,6 +2115,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X DELETE \
@@ -1775,6 +2125,8 @@ curl -X DELETE \
   https://api.clarifai.com/v2/models/
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1789,6 +2141,8 @@ you can get the model to predict exactly how you want it to.*
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.train("{model_id}").then(
@@ -1813,6 +2167,9 @@ model.train().then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1822,12 +2179,18 @@ model.train()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.trainModel("{model_id}").executeSync();
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1850,6 +2213,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/puppy.jpg"]
@@ -1861,6 +2227,9 @@ ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clar
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Models\ModelType;
@@ -1881,6 +2250,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -1889,6 +2261,8 @@ curl -X POST \
   https://api.clarifai.com/v2/models/{model_id}/versions
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -1900,6 +2274,8 @@ predictions. The predictions returned will only contain the concepts that you to
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.predict("{model_id}", ["https://samples.clarifai.com/puppy.jpg"]).then(
@@ -1924,6 +2300,9 @@ model.predict("https://samples.clarifai.com/puppy.jpg").then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -1933,6 +2312,9 @@ model = app.models.get('YOUR_MODEL_ID')
 response = model.predict_by_url('https://samples.clarifai.com/puppy.jpg')
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.predict("{model_id}")
@@ -1943,6 +2325,9 @@ client.predict("{model_id}")
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -1968,6 +2353,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/puppy.jpg"]
@@ -1980,6 +2368,9 @@ ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clar
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -2015,6 +2406,9 @@ if ($response->isSuccessful()) {
 ```
 
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -2035,6 +2429,8 @@ curl -X POST \
   https://api.clarifai.com/v2/models/{model_id}/outputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -2044,6 +2440,8 @@ You can search all your models by name and type of model.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.search('general-v1.3', 'concept').then(
@@ -2057,6 +2455,9 @@ app.models.search('general-v1.3', 'concept').then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -2069,6 +2470,9 @@ app.models.search(model_name='general-v1.3', model_type='concept')
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.findModel()
@@ -2079,6 +2483,9 @@ client.findModel()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -2103,6 +2510,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app searchForModelByName:@"general-v1.3" modelType:ClarifaiModelTypeConcept completion:^(NSArray<ClarifaiModel *> *models, NSError *error) {
@@ -2111,6 +2521,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -2140,6 +2553,9 @@ if ($response->isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -2155,5 +2571,5 @@ curl -X POST \
   https://api.clarifai.com/v2/models/searches
 
 ```
-
-
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/pagination.md
+++ b/pagination.md
@@ -5,12 +5,17 @@ we are getting all inputs and specifying to start at page 2 and get back 20 resu
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.list({page: 2, perPage: 20});
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -19,6 +24,9 @@ app.inputs.get_by_page(page=2, per_page=20)
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.getInputs()
@@ -28,6 +36,9 @@ client.getInputs()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -51,6 +62,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app getInputsOnPage:2 pageSize:20 completion:^(NSArray<ClarifaiInput *> *inputs, NSError *error) {
@@ -59,6 +73,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiInput;
@@ -86,6 +103,9 @@ if ($response->isSuccessful()) {
 }
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X GET \
@@ -93,5 +113,5 @@ curl -X GET \
   https://api.clarifai.com/v2/inputs?page=2&per_page=20
 
 ```
-
-
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/predict.md
+++ b/predict.md
@@ -84,8 +84,8 @@ namespace YourNamespace
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="objectivec" %}
-```objectivec
+{% code-tabs-item title="objective-c" %}
+```objective-c
 ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"@@sampleTrain"];
 [_app getModelByName:@"general-v1.3" completion:^(ClarifaiModel *model, NSError *error) {
     [model predictOnImages:@[image]
@@ -326,11 +326,6 @@ curl -X POST
 Below is an example of how you would send the bytes of an image and receive back predictions from the `general` model.
 
 {% code-tabs %}
-{% code-tabs-item title="text" %}
-```text
-
-```
-{% endcode-tabs-item %}
 
 {% code-tabs-item title="javascript" %}
 ```javascript
@@ -389,8 +384,8 @@ namespace YourNamespace
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="text" %}
-```text
+{% code-tabs-item title="obj-c" %}
+```objective-c
 UIImage *image = [UIImage imageNamed:@"dress.jpg"];
 ClarifaiImage *clarifaiImage = [[ClarifaiImage alloc] initWithImage:image];
 [_app getModelByName:@"general-v1.3" completion:^(ClarifaiModel *model, NSError *error) {
@@ -475,13 +470,9 @@ FILEIN
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="text" %}
-```text
-
-```
-{% endcode-tabs-item %}
 {% endcode-tabs %}
 
+Response:
 ```javascript
 {
   "status": {
@@ -668,11 +659,6 @@ If your video exceeds the limits, please follow our [tutorial](https://docs.goog
 Below is an example of how you would send video URLs and receive back predictions from the `general` model.
 
 {% code-tabs %}
-{% code-tabs-item title="text" %}
-```text
-
-```
-{% endcode-tabs-item %}
 
 {% code-tabs-item title="javascript" %}
 ```javascript
@@ -834,8 +820,8 @@ namespace YourPackageName
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="text" %}
-```text
+{% code-tabs-item title="objective-c" %}
+```objective-c
 Objective-C client details coming soon
 ```
 {% endcode-tabs-item %}
@@ -882,8 +868,8 @@ if ($response->isSuccessful()) {
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="text" %}
-```text
+{% code-tabs-item title="bash" %}
+```bash
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -909,16 +895,10 @@ curl -X POST \
   https://api.clarifai.com/v2/models/@@generalModelId/outputs
 ```
 {% endcode-tabs-item %}
-
-{% code-tabs-item title="text" %}
-```text
-
-```
-{% endcode-tabs-item %}
 {% endcode-tabs %}
 
-
-```javascript
+Response
+```json
 {
   "status": {
     "code": 10000,
@@ -2143,11 +2123,6 @@ curl -X POST \
 Below is an example of how you would send the bytes of a video and receive back predictions from the general model.
 
 {% code-tabs %}
-{% code-tabs-item title="text" %}
-```text
-
-```
-{% endcode-tabs-item %}
 
 {% code-tabs-item title="javascript" %}
 ```javascript
@@ -2311,8 +2286,8 @@ namespace YourPackageName
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="text" %}
-```text
+{% code-tabs-item title="objective-c" %}
+```objective-c
 Objective-C client details coming soon
 ```
 {% endcode-tabs-item %}
@@ -2359,8 +2334,8 @@ if ($response->isSuccessful()) {
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="text" %}
-```text
+{% code-tabs-item title="bash" %}
+```bash
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -2386,15 +2361,10 @@ curl -X POST \
   https://api.clarifai.com/v2/models/@@generalModelId/outputs
 ```
 {% endcode-tabs-item %}
+{% endcode-tabs %}
 
-{% code-tabs-item title="text" %}
-```text
-
-```
-{% endcode-tabs-item %}
-
-{% code-tabs-item title="text" %}
-```text
+Response:
+```json
 {
     "status": {
         "code": 10000,
@@ -2574,6 +2544,5 @@ curl -X POST \
     ]
 }
 ```
-{% endcode-tabs-item %}
-{% endcode-tabs %}
+
 

--- a/predict.md
+++ b/predict.md
@@ -21,8 +21,8 @@ Below is an example of how you would send image URLs and receive back prediction
 You can learn all about the different [public models](public-models.md) available later in the guide.
 
 {% code-tabs %}
-{% code-tabs-item title="javascript" %}
-```javascript
+{% code-tabs-item title="js" %}
+```js
 app.models.initModel({id: Clarifai.GENERAL_MODEL, version: "aa7f35c01e0642fda5cf400f543e7c40"})
       .then(generalModel => {
         return generalModel.predict("@@sampleTrain");
@@ -130,8 +130,8 @@ if ($response->isSuccessful()) {
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="bash" %}
-```bash
+{% code-tabs-item title="cURL" %}
+```cURL
 curl -X POST
     -H 'Authorization: Key YOUR_API_KEY'
     -H "Content-Type: application/json"
@@ -152,7 +152,9 @@ curl -X POST
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-```javascript
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -320,6 +322,8 @@ curl -X POST
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 **Via Bytes**
 
@@ -327,8 +331,9 @@ Below is an example of how you would send the bytes of an image and receive back
 
 {% code-tabs %}
 
-{% code-tabs-item title="javascript" %}
-```javascript
+{% code-tabs-item title="js" %}
+{% code-tabs-item title="js" %}
+```js
 app.models.predict(Clarifai.GENERAL_MODEL, {base64: "G7p3m95uAl..."}).then(
   function(response) {
     // do something with response
@@ -428,8 +433,8 @@ if ($response->isSuccessful()) {
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="text" %}
-```text
+{% code-tabs-item title="cURL" %}
+```cURL
 // Smaller files (195 KB or less)
 
 curl -X POST \
@@ -469,11 +474,11 @@ curl -X POST \
 FILEIN
 ```
 {% endcode-tabs-item %}
-
 {% endcode-tabs %}
 
-Response:
-```javascript
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -641,6 +646,8 @@ Response:
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 #### Videos
 
@@ -660,8 +667,9 @@ Below is an example of how you would send video URLs and receive back prediction
 
 {% code-tabs %}
 
-{% code-tabs-item title="javascript" %}
-```javascript
+{% code-tabs-item title="js" %}
+{% code-tabs-item title="js" %}
+```js
 const Clarifai = require('clarifai');
 
 const app = new Clarifai.App({apiKey: 'YOUR_API_KEY'});
@@ -868,8 +876,8 @@ if ($response->isSuccessful()) {
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="bash" %}
-```bash
+{% code-tabs-item title="cURL" %}
+```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -897,7 +905,8 @@ curl -X POST \
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-Response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
 ```json
 {
   "status": {
@@ -2117,6 +2126,8 @@ Response
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 **Via Bytes**
 
@@ -2124,8 +2135,9 @@ Below is an example of how you would send the bytes of a video and receive back 
 
 {% code-tabs %}
 
-{% code-tabs-item title="javascript" %}
-```javascript
+{% code-tabs-item title="js" %}
+{% code-tabs-item title="js" %}
+```js
 const Clarifai = require('clarifai');
 
 const app = new Clarifai.App({apiKey: 'YOUR_API_KEY'});
@@ -2334,8 +2346,8 @@ if ($response->isSuccessful()) {
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title="bash" %}
-```bash
+{% code-tabs-item title="cURL" %}
+```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -2363,7 +2375,8 @@ curl -X POST \
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-Response:
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
 ```json
 {
     "status": {
@@ -2544,5 +2557,5 @@ Response:
     ]
 }
 ```
-
-
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/predict.md
+++ b/predict.md
@@ -332,7 +332,6 @@ Below is an example of how you would send the bytes of an image and receive back
 {% code-tabs %}
 
 {% code-tabs-item title="js" %}
-{% code-tabs-item title="js" %}
 ```js
 app.models.predict(Clarifai.GENERAL_MODEL, {base64: "G7p3m95uAl..."}).then(
   function(response) {
@@ -667,7 +666,6 @@ Below is an example of how you would send video URLs and receive back prediction
 
 {% code-tabs %}
 
-{% code-tabs-item title="js" %}
 {% code-tabs-item title="js" %}
 ```js
 const Clarifai = require('clarifai');
@@ -2135,7 +2133,6 @@ Below is an example of how you would send the bytes of a video and receive back 
 
 {% code-tabs %}
 
-{% code-tabs-item title="js" %}
 {% code-tabs-item title="js" %}
 ```js
 const Clarifai = require('clarifai');

--- a/search.md
+++ b/search.md
@@ -13,8 +13,8 @@ The Search API allows you to send images \(url or bytes\) to the service and hav
 To get started with search, you must first add images to the search index. You can add one or more images to the index at a time. You can supply an image either with a publicly accessible URL or by directly sending image bytes. You can send up to 128 images in one API call.
 
 {% code-tabs %}
-{% code-tabs-item title="JavaScript" %}
-```javascript
+{% code-tabs-item title="js" %}
+```js
 app.inputs.create([
   {url: "https://samples.clarifai.com/metro-north.jpg"},
   {url: "https://samples.clarifai.com/wedding.jpg"},
@@ -31,7 +31,7 @@ app.inputs.create([
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 from clarifai.rest import Image as ClImage
@@ -46,7 +46,7 @@ app.inputs.bulk_create_images([img1, img2, img3])
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
+{% code-tabs-item title=java %}
 ```java
 client.addInputs()
     .plus(
@@ -57,7 +57,7 @@ client.addInputs()
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
+{% code-tabs-item title=csharp %}
 ```csharp
 using System.Threading.Tasks;
 using Clarifai.API;
@@ -81,8 +81,8 @@ namespace YourNamespace
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
-```objectivec
+{% code-tabs-item title=objective-c %}
+```objective-c
 ClarifaiImage *image1 = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/metro-north.jpg"];
 ClarifaiImage *image2 = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/wedding.jpg"];
 
@@ -92,7 +92,7 @@ ClarifaiImage *image2 = [[ClarifaiImage alloc] initWithURL:@"https://samples.cla
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Inputs\ClarifaiURLImage;
@@ -115,8 +115,8 @@ if ($response-> isSuccessful()) {
 ```
 {% endcode-tabs-item %}
 
-{% code-tabs-item title=undefined %}
-```bash
+{% code-tabs-item title=cURL %}
+```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -146,7 +146,7 @@ curl -X POST \
 
 {% code-tabs %}
 {% code-tabs-item title="Response JSON" %}
-```javascript
+```json
 {
   "status": {
     "code": 10000,
@@ -190,7 +190,9 @@ th.jpg"
 
 Once your images are indexed, you can search for them by concept.
 
-```javascript
+{% code-tabs %}
+{% code-tabs-item title="js" %}
+```js
 app.inputs.search({ concept: {name: 'people'} }).then(
   function(response) {
     // do something with response
@@ -201,6 +203,9 @@ app.inputs.search({ concept: {name: 'people'} }).then(
 );
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -218,12 +223,18 @@ app.inputs.search_by_predicted_concepts(concept_id='ai_dP13sXL4')
 app.inputs.search_by_predicted_concepts(concept_ids=['ai_dP13sXL4'])
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 client.searchInputs(SearchClause.matchConcept(Concept.forName("people")))
     .getPage(1)
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 using System.Threading.Tasks;
 using Clarifai.API;
@@ -245,7 +256,10 @@ namespace YourNamespace
 }
 ```
 
-```text
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
+```objective-c
 // First create a search term with a concept you want to search.
 ClarifaiConcept *conceptFromGeneralModel = [[ClarifaiConcept alloc] initWithConceptName:@"people"];
 ClarifaiSearchTerm *searchTerm = [ClarifaiSearchTerm searchByPredictedConcept:conceptFromGeneralModel];
@@ -258,6 +272,9 @@ ClarifaiSearchTerm *searchTerm = [ClarifaiSearchTerm searchByPredictedConcept:co
 }];
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Searches\SearchBy;
@@ -282,7 +299,10 @@ if ($response-> isSuccessful()) {
 }
 ```
 
-```text
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
+```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -307,7 +327,9 @@ curl -X POST \
   https://api.clarifai.com/v2/searches
 ```
 
-```text
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -334,12 +356,17 @@ curl -X POST \
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 #### Search By Image
 
 You can also search for images using another image. In this case, you provide an image \(url or bytes\) and the results will return all the images in your search index that are visually similar to the one provided.
 
-```javascript
+
+{% code-tabs %}
+{% code-tabs-item title="js" %}
+```js
 app.inputs.search({ input: {url: 'https://samples.clarifai.com/puppy.jpg'} }).then(
   function(response) {
     // do something with response
@@ -350,6 +377,9 @@ app.inputs.search({ input: {url: 'https://samples.clarifai.com/puppy.jpg'} }).th
 );
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -378,12 +408,18 @@ fio = open("filename_on_local_disk.jpg", 'rb')
 app.inputs.search_by_image(fileobj=fio)
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 client.searchInputs(SearchClause.matchImageVisually(ClarifaiImage.of("https://samples.clarifai.com/metro-north.jpg")))
     .getPage(1)
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 using System.Threading.Tasks;
 using Clarifai.API;
@@ -405,7 +441,10 @@ namespace YourNamespace
 }
 ```
 
-```text
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
+```objective-c
 ClarifaiSearchTerm *searchTerm = [ClarifaiSearchTerm searchVisuallyWithImageURL:@"https://samples.clarifai.com/metro-north.jpg"];
 
 [app search:@[searchTerm] page:@1 perPage:@20 completion:^(NSArray<ClarifaiSearchResult *> *results, NSError *error) {
@@ -416,6 +455,9 @@ ClarifaiSearchTerm *searchTerm = [ClarifaiSearchTerm searchVisuallyWithImageURL:
 }];
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 use Clarifai\API\ClarifaiClient;
 use Clarifai\DTOs\Searches\SearchBy;
@@ -442,7 +484,10 @@ if ($response-> isSuccessful()) {
 }
 ```
 
-```text
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
+```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -466,8 +511,12 @@ curl -X POST \
   }'\
   https://api.clarifai.com/v2/searches
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
-```text
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -510,4 +559,5 @@ curl -X POST \
   ]
 }
 ```
-
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/train.md
+++ b/train.md
@@ -9,7 +9,7 @@ see how you would like it to see, you can then use that model to make prediction
 
 You do not need many images to get started. We recommend starting with 10 and adding more as needed. Before you train your first model you will have needed to [create an application](applications.md#create-an-application). From there you will be able to change your [Base Workflow](applications#base-workflow) to optimize custom training using the knowledge base from select public models.
 
-![inputs outputs](/images/illustration-training.png)  
+![inputs outputs](/images/illustration-training.png)
 
 ### Add Images With Concepts
 
@@ -18,6 +18,8 @@ your model to see.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.inputs.create({
@@ -32,6 +34,9 @@ app.inputs.create({
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 from clarifai.rest import Image as ClImage
@@ -46,6 +51,9 @@ app.inputs.bulk_create_images([img1, img2])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.addInputs()
@@ -56,6 +64,9 @@ client.addInputs()
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -83,6 +94,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/puppy.jpg" andConcepts:@"cute puppy"];
@@ -92,6 +106,9 @@ ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clar
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -117,6 +134,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -143,11 +163,15 @@ curl -X POST \
   https://api.clarifai.com/v2/inputs
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 
 {
   "status": {
@@ -180,6 +204,8 @@ curl -X POST \
 }
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### Create A Model
 
@@ -190,6 +216,8 @@ Take note of the `model id` that is returned in the response. You'll need that f
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.create(
@@ -208,6 +236,9 @@ app.models.create(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -216,6 +247,9 @@ model = app.models.create('pets', concepts=['boscoe'])
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.createModel("pets")
@@ -225,6 +259,9 @@ client.createModel("pets")
     .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -250,6 +287,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 [app createModel:@[concept] name:modelName conceptsMutuallyExclusive:NO closedEnvironment:NO
@@ -259,6 +299,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -281,6 +324,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -308,11 +354,15 @@ curl -X POST \
   https://api.clarifai.com/v2/models
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 
 {
   "status": {
@@ -344,6 +394,8 @@ curl -X POST \
 }
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### Train The Model
 
@@ -352,10 +404,12 @@ train the model. When you train a model, you are telling the system to look at a
 you've provided and learn from them. This train operation is asynchronous. It may take a few seconds for your
 model to be fully trained and ready.
 
-Keep note of the `model_version id` in the response. We'll need that for the next section when we predict with the model. 
+Keep note of the `model_version id` in the response. We'll need that for the next section when we predict with the model.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 app.models.train("{model_id}").then(
@@ -380,6 +434,9 @@ model.train().then(
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 
@@ -390,11 +447,17 @@ model.train()
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 client.trainModel("{model_id}").executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -417,6 +480,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/puppy.jpg"]
@@ -428,6 +494,9 @@ ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clar
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -449,6 +518,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -457,11 +529,15 @@ curl -X POST \
   https://api.clarifai.com/v2/models/<model_id>/versions
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 
 {
   "status": {
@@ -493,10 +569,12 @@ curl -X POST \
 }
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 ### Predict With The Model
 
-Now that we have a trained model. We can start making predictions with it. In our predict call we need to specify three items. 
+Now that we have a trained model. We can start making predictions with it. In our predict call we need to specify three items.
 The `model id`, `model_version id` and the `input` we want a prediction for.
 
 *Note: you can repeat the above steps as often as you like. By adding more images with concepts and training,
@@ -504,6 +582,8 @@ you can get the model to predict exactly how you want it to.*
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 
 let app = new Clarifai.App({apiKey: 'YOUR_API_KEY'});
@@ -520,6 +600,9 @@ app.models.predict({id:'MODEL_ID', version:'MODEL_VERSION_ID'}, "https://samples
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 app = ClarifaiApp(api_key='YOUR_API_KEY')
@@ -530,6 +613,9 @@ model.model_version = 'MODEL_VERSION_ID'  # This is optional. Defaults to the la
 response = model.predict_by_url('https://samples.clarifai.com/metro-north.jpg')
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 
 ModelVersion modelVersion = client.getModelVersionByID("MODEL_ID", "MODEL_VERSION_ID")
@@ -544,6 +630,9 @@ ModelVersion modelVersion = client.getModelVersionByID("MODEL_ID", "MODEL_VERSIO
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Threading.Tasks;
@@ -571,6 +660,9 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 
 ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clarifai.com/puppy.jpg"]
@@ -583,6 +675,9 @@ ClarifaiImage *image = [[ClarifaiImage alloc] initWithURL:@"https://samples.clar
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -615,6 +710,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -636,10 +734,14 @@ curl -X POST \
 
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 
 {
   "status": {
@@ -699,3 +801,5 @@ curl -X POST \
 }
 
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/video.md
+++ b/video.md
@@ -13,6 +13,8 @@ by providing the `ModelId` parameter as outlined in the [Predict API](predict.md
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.models.predict(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/beer.mp4', {video: true})
   .then(response => {
@@ -23,6 +25,9 @@ app.models.predict(Clarifai.GENERAL_MODEL, 'https://samples.clarifai.com/beer.mp
   });
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import Video as ClVideo
 
@@ -31,6 +36,9 @@ video = ClVideo(url='https://samples.clarifai.com/beer.mp4')
 model.predict([video])
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 ClarifaiResponse<List<ClarifaiOutput<Frame>>> frames = client.getDefaultModels().generalVideoModel().predict()
        .withInputs(
@@ -39,10 +47,23 @@ ClarifaiResponse<List<ClarifaiOutput<Frame>>> frames = client.getDefaultModels()
        .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
+```csharp
+// Coming Soon
+```
+{% endcode-tabs-item %}
+
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 Objective-C client details coming soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 
 curl -X POST \
@@ -62,6 +83,8 @@ curl -X POST \
   }'\
   https://api.clarifai.com/v2/models/aaa03c23b3724a16a56b629203edc62c/outputs
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -70,6 +93,8 @@ curl -X POST \
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.models.predict(Clarifai.GENERAL_MODEL, {base64: 'AAAAIGZ...'}, {video: true})
   .then(response => {
@@ -80,6 +105,9 @@ app.models.predict(Clarifai.GENERAL_MODEL, {base64: 'AAAAIGZ...'}, {video: true}
   });
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import Video as ClVideo
 
@@ -88,6 +116,9 @@ video = ClVideo(filename='/home/user/video.mp4')
 model.predict([video])
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 ClarifaiResponse<List<ClarifaiOutput<Frame>>> frames = client.getDefaultModels().generalVideoModel().predict()
        .withInputs(
@@ -96,10 +127,23 @@ ClarifaiResponse<List<ClarifaiOutput<Frame>>> frames = client.getDefaultModels()
        .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
+```csharp
+// Coming Soon
+```
+{% endcode-tabs-item %}
+
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 Objective-C client details coming soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 curl -X POST \
   -H "Authorization: Key YOUR_API_KEY" \
@@ -118,6 +162,8 @@ curl -X POST \
   }'\
   https://api.clarifai.com/v2/models/aaa03c23b3724a16a56b629203edc62c/outputs
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
@@ -139,7 +185,9 @@ If the video input exceeds the limits, the processing will time out and you will
 If your video exceeds the above limits, please follow our [tutorial](http://help.clarifai.com/videos/how-to-split-video-files-into-smaller-pieces) on how to break up a large
 video into smaller components, and send those components into the Video API.
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -1358,3 +1406,5 @@ video into smaller components, and send those components into the Video API.
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}

--- a/workflow.md
+++ b/workflow.md
@@ -1,10 +1,10 @@
 ## Workflow
 
-Workflows are a new entity added to Clarifai, which encompass one or more Public or 
-Custom model(s). Every workflow is attached to one of your applications. 
+Workflows are a new entity added to Clarifai, which encompass one or more Public or
+Custom model(s). Every workflow is attached to one of your applications.
 Under each workflow, you will see a list of the public models and all custom models in
-that application when selecting models to add to your workflow. With Workflow Predict, you 
-will be able to reduce the latency and in turn make your product more efficient. 
+that application when selecting models to add to your workflow. With Workflow Predict, you
+will be able to reduce the latency and in turn make your product more efficient.
 
 Note: this won't have any impact on the price you are charged per call.
 You will still be charged for the same operation if it were separate calls to the API.
@@ -24,11 +24,11 @@ Then under that application, you will see a section labeled "App Workflows" and 
 ![Image showing My First Application and the Create Workflow button underneath the
 Create API Key](/images/create-workflow-new.png)
 
-After that, the page will reveal a new workflow form to fill out. Fill out the 
+After that, the page will reveal a new workflow form to fill out. Fill out the
 Workflow ID field, this will be used to make the API call, so make sure to
 give it something URL friendly! Included there, you will also a list that consists of a model
 field and a version associated with it. For the public models, you will be mandated
-to use the latest version. For your custom models, you will be able to 
+to use the latest version. For your custom models, you will be able to
 [select the version of your model](models.md#list-model-versions)</a>. To add another model, you will just click underneath your
 latest addition on the "Add Model". The max limit of models associated with any given workflow
 is 5 models. If you would like to remove a model, there is a
@@ -41,8 +41,8 @@ time, in case you don't like it.
 under a workflow with the name my-workflow](/images/my-workflow-new.png)
 
 ### Workflow Predict
-The Workflow Predict API allows you to predict using 1 or more model(s), regardless of them 
-being public or custom, within a single API call! The max number of inputs processed at once with 
+The Workflow Predict API allows you to predict using 1 or more model(s), regardless of them
+being public or custom, within a single API call! The max number of inputs processed at once with
 any given workflow is 32.
 
 Now that you have that all set up, you will be able to predict under a workflow using
@@ -58,6 +58,8 @@ a given input.
 
 
 
+{% code-tabs %}
+{% code-tabs-item title="js" %}
 ```js
 app.workflow.predict('{workflow-id}', "https://samples.clarifai.com/metro-north.jpg").then(
     function(response){
@@ -69,6 +71,9 @@ app.workflow.predict('{workflow-id}', "https://samples.clarifai.com/metro-north.
 );
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=python %}
 ```python
 from clarifai.rest import ClarifaiApp
 from clarifai.rest import Workflow
@@ -79,12 +84,18 @@ workflow = Workflow(app.api, workflow_id="YOUR_WORKFLOW_ID")
 response = workflow.predict_by_url('https://samples.clarifai.com/metro-north.jpg')
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=java %}
 ```java
 client.workflowPredict("{workflow-id}")
         .withInputs(ClarifaiInput.forImage("https://samples.clarifai.com/metro-north.jpg"))
         .executeSync();
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=csharp %}
 ```csharp
 
 using System.Collections.Generic;
@@ -113,10 +124,16 @@ namespace YourNamespace
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=objective-c %}
 ```objective-c
 // Coming Soon
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=php %}
 ```php
 
 use Clarifai\API\ClarifaiClient;
@@ -154,6 +171,9 @@ if ($response-> isSuccessful()) {
 
 ```
 
+{% endcode-tabs-item %}
+
+{% code-tabs-item title=cURL %}
 ```cURL
 curl -X POST \
   -H 'authorization: Key YOUR_API_KEY' \
@@ -166,15 +186,19 @@ curl -X POST \
               "url": "https://samples.clarifai.com/metro-north.jpg"
           }
         }
-      }  
+      }
     ]
 }'\
 https://api.clarifai.com/v2/workflows/{workflow-id}/results
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
 
 
 
-```response
+{% code-tabs %}
+{% code-tabs-item title="Response JSON" %}
+```json
 {
   "status": {
     "code": 10000,
@@ -417,3 +441,5 @@ https://api.clarifai.com/v2/workflows/{workflow-id}/results
   ]
 }
 ```
+{% endcode-tabs-item %}
+{% endcode-tabs %}


### PR DESCRIPTION
Only predict and search really had this setup.

These were the cleanups as well to the type of code block: 
- [x] Cleaned up response -> json format
- [x] Wrapped responses in code block format as well. 
- [x] javascript -> js
- [x] bash -> cURL 