### PR TITLE
Fixed "more about workflows here" link

### DIFF
--- a/getting-started/applications/base-workflows.md
+++ b/getting-started/applications/base-workflows.md
@@ -8,7 +8,7 @@ For example, if you're training a custom model to recognize your restaurant's di
 
 ![](../../images/base_workflow.jpg)
 
-You currently have the option of using our General, Travel, Food, Face, Moderation, and Wedding models in your base workflow. More information on these, and other Clarifai Models can be found in our [model gallery](https://www.clarifai.com/models). You can learn more about workflows [here](https://docs.clarifai.com/main/api-guide/model/workflow/).
+You currently have the option of using our General, Travel, Food, Face, Moderation, and Wedding models in your base workflow. More information on these, and other Clarifai Models can be found in our [model gallery](https://www.clarifai.com/models). You can learn more about workflows [here](https://docs.clarifai.com/api-guide/workflows).
 
 {% hint style="info" %}
 We recommend choosing the 'General' model if you're not sure which Clarifai Model would best suit your use case.


### PR DESCRIPTION
The link for more about workflows (https://docs.clarifai.com/main/api-guide/model/workflow/) was broken. Based on context, it should probably point to this updated link: https://docs.clarifai.com/api-guide/workflows