### PR TITLE
Code examples tests

### DIFF
--- a/.github/workflows/test-code-examples.yml
+++ b/.github/workflows/test-code-examples.yml
@@ -1,0 +1,27 @@
+name: Test code examples
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        cd tests
+        pip install -r requirements.txt
+    - name: Run code examples tests
+      run: |
+        cd tests
+        python run_code_examples_tests.py

--- a/.github/workflows/test-code-examples.yml
+++ b/.github/workflows/test-code-examples.yml
@@ -1,10 +1,6 @@
 name: Test code examples
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/api-guide/walkthroughs/custom-text-model-walkthrough.md
+++ b/api-guide/walkthroughs/custom-text-model-walkthrough.md
@@ -39,10 +39,10 @@ post_apps_response = stub.PostApps(
 # You may print the response to see what the structure and the data of the response is.
 # print(post_apps_response)
 
-user_id = post_apps_response.apps[0].user_id
-
 if post_apps_response.status.code != status_code_pb2.SUCCESS:
     raise Exception("Failed response, status: " + str(post_apps_response.status))
+
+user_id = post_apps_response.apps[0].user_id
 ```
 {% endtab %}
 {% endtabs %}

--- a/api-guide/walkthroughs/custom-text-model-walkthrough.md
+++ b/api-guide/walkthroughs/custom-text-model-walkthrough.md
@@ -158,6 +158,8 @@ Let's now wait for all the inputs to download.
 {% tabs %}
 {% tab title="gRPC Python" %}
 ```python
+import time
+
 while True:
     list_inputs_response = stub.ListInputs(
         service_pb2.ListInputsRequest(page=1, per_page=100),
@@ -255,6 +257,8 @@ Each model training produces a new model version. See on the bottom of the code 
 {% tabs %}
 {% tab title="gRPC Python" %}
 ```python
+import time
+
 while True:
     get_model_response = stub.GetModel(
         service_pb2.GetModelRequest(model_id="my-text-model"),
@@ -351,6 +355,8 @@ Model evaluation takes some time, depending on the amount of data in our model. 
 {% tabs %}
 {% tab title="gRPC Python" %}
 ```python
+import time
+
 while True:
     get_model_version_metrics_response = stub.GetModelVersionMetrics(
         service_pb2.GetModelVersionMetricsRequest(

--- a/api-guide/walkthroughs/custom-text-model-walkthrough.md
+++ b/api-guide/walkthroughs/custom-text-model-walkthrough.md
@@ -324,7 +324,7 @@ for output in post_model_outputs_response.outputs:
 
 ## Start model evaluation
 
-Let's now test the performance of the model by using model evaluation. See the [the Model Evaluation page](../../api-guide/model/evaluate) to learn more.
+Let's now test the performance of the model by using model evaluation. See the [the Model Evaluation page](https://docs.clarifai.com/portal-guide/model/evaluate) to learn more.
 
 {% tabs %}
 {% tab title="gRPC Python" %}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+clarifai-grpc

--- a/tests/run_code_examples_tests.py
+++ b/tests/run_code_examples_tests.py
@@ -1,0 +1,111 @@
+import os
+
+
+def read_init_code():
+  init_lines = []
+
+  with open("../api-guide/api-overview/api-clients.md") as f:
+    in_install_instructions = False
+    in_python_initialize_client = False
+    for line in f:
+      line = line[:-1]  # Remove ending newline char
+      if in_python_initialize_client:
+        if line == "```":
+          break
+        init_lines.append(line)
+      elif in_install_instructions:
+        if line.startswith("# Initialize client"):
+          in_python_initialize_client = True
+      elif line.startswith("## Client Installation Instructions"):
+        in_install_instructions = True
+
+
+  init_script = "\n".join(init_lines)
+  init_script += "\n\n"
+  return init_script
+
+
+def read_code_examples(file_path):
+  code_lines = []
+  with open("../api-guide/" + file_path) as f:
+    num = 1
+    in_python_code = False
+    title = ""
+    for line in f:
+      line = line[:-1]  # Remove ending newline char
+      if in_python_code:
+        if line == "```":
+          in_python_code = False
+          code_lines.append("\n\n")
+        else:
+          code_lines.append(line)
+      elif line == "```python":
+        in_python_code = True
+        code_lines.append("#")
+        code_lines.append(f"# Code example ({num}): {title}")
+        code_lines.append("#")
+        num += 1
+      elif line.startswith("## "):
+        title = line[len("## "):]
+  return "\n".join(code_lines)
+
+
+def make_test_setup_code(code_examples):
+  """
+  Extends the documentation code examples with code that needs to be run in
+  order for tests to succeed.
+
+  For example, before each PostApps, we add a DeleteApp of that app_id,
+  to delete any possible previous existing app.
+  """
+  creates_app = False
+  app_id = ""
+  for line in code_examples.split("\n"):
+    if "stub.PostApps" in line:
+      creates_app = True
+    elif creates_app and not app_id and "id=" in line:
+      app_id = line.strip()[len('id="'):-len(",)")]
+
+  code_examples = ""
+  if app_id:
+    code_examples = """
+# This is not part of the docs. It is added to the test run, to clean up
+# any possible app with this name from any previous (failed) test runs.
+stub.DeleteApp(
+    service_pb2.DeleteAppRequest(
+        user_app_id=resources_pb2.UserAppIDSet(user_id="me", app_id="%s")
+    ),
+    metadata=(('authorization', 'Key %s'),)
+)
+
+""" % (app_id, PAT)
+
+  return code_examples
+
+
+if __name__ == "__main__":
+  PAT = os.environ["TEST_RUNNER_PAT"]
+
+  file_paths = [
+    "walkthroughs/custom-text-model-walkthrough.md"
+  ]
+
+  init_code = read_init_code()
+  for file_path in file_paths:
+    code_examples = read_code_examples(file_path)
+
+    test_setup_code = make_test_setup_code(code_examples)
+
+    total_code = init_code + test_setup_code + code_examples
+    total_code = total_code.replace("{YOUR_PERSONAL_ACCESS_TOKEN}", PAT)
+
+    print("### Testing code examples in " + file_path)
+    print("### The following code will be run:")
+    print()
+
+    for i, line in enumerate(total_code.split("\n")):
+      print(f"{i + 1:5d} | {line}")
+
+    print()
+    print("### Running the code, standard output:")
+    exec(total_code)


### PR DESCRIPTION
Add a script that parses and runs code examples.

Currently, it runs a single walkthrough: custom text model walkthrough. It's not too smart right now, but smart enough to delete an app if it has remained from a previous (failed) run.