### PR TITLE
Update how Node init requires 'grpc'

### DIFF
--- a/api-guide/api-overview/api-clients.md
+++ b/api-guide/api-overview/api-clients.md
@@ -120,8 +120,7 @@ npm install clarifai-nodejs-grpc
 // Initialize client
 ///////////////////////////////////////////////////////////////////////////////
 
-const {ClarifaiStub} = require("clarifai-nodejs-grpc");
-const grpc = require("@grpc/grpc-js");
+const {ClarifaiStub, grpc} = require("clarifai-nodejs-grpc");
 
 const stub = ClarifaiStub.grpc();
 


### PR DESCRIPTION
This updates the NodeJS code example on how the `grpc` dependency should be imported.