### PR TITLE
eliminated incorrect usage of old clients in Authorize page

### DIFF
--- a/clarifai-basics/authentication/authorize.md
+++ b/clarifai-basics/authentication/authorize.md
@@ -1,25 +1,36 @@
 # Authorize
 
-After creating your `API Key`, you are ready to make API calls. If you are using a client, authentication will be handled for you. If you are using the REST API, you will need to add the `Authorization` header as described in the cURL example.
+After creating your `API Key`, you are ready to make API calls. Most
+clients set up authentication when initilizing the client, it can be
+changed for particular requests if needed. If you are using the REST
+API, you will need to add the `Authorization` header as described in
+the cURL example.
 
 {% tabs %}
 {% tab title="js" %}
 ```javascript
-const app = new Clarifai.App({apiKey: 'YOUR_API_KEY'});
+// Authentication done at grpc stub initialization time see:
+//
+https://docs.clarifai.com/api-guide/api-overview/api-clients#client-installation-instructions
+metadata.set("authorization", "Key YOUR_CLARIFAI_API_KEY");
 ```
 {% endtab %}
 
 {% tab title="python" %}
 ```python
-from clarifai.rest import ClarifaiApp
+metadata = (('authorization', 'Key YOUR_API_KEY'),)
+# Yes the word 'Key' appears in addition to the alphanumeric API_KEY
 
-app = ClarifaiApp(api_key='YOUR_API_KEY')
 ```
 {% endtab %}
 
 {% tab title="java" %}
 ```java
-new ClarifaiBuilder("YOUR_API_KEY").buildSync();
+// Authentication done at grpc stub initialization time see:
+//
+https://docs.clarifai.com/api-guide/api-overview/api-clients#client-installation-instructions
+V2Grpc.V2BlockingStub stub = V2Grpc.newBlockingStub(ClarifaiChannel.INSTANCE.getGrpcChannel())
+    .withCallCredentials(new ClarifaiCallCredentials("YOUR_CLARIFAI_API_KEY"));
 ```
 {% endtab %}
 
@@ -65,5 +76,10 @@ curl -X POST \
 {% endtab %}
 {% endtabs %}
 
-If the API Key does not have the required scope\(s\) to execute a given request, you will get an error message reporting the missing scopes and/or endpoints that your key needs to execute this request.
+If the API Key does not have the required scope\(s\) to execute a
+given request, you will get an error message reporting the missing
+scopes and/or endpoints that your key needs to execute this
+request. An invalid key may be reported as 'API key not
+found'. Failure to include a required key may result simple in
+'Invalid request'.
 

--- a/tests/run_code_examples_tests.py
+++ b/tests/run_code_examples_tests.py
@@ -4,7 +4,7 @@ import os
 def read_init_code():
   init_lines = []
 
-  with open("../api-guide/api-overview/api-clients.md") as f:
+  with open("../api-guide/api-overview/api-clients/README.md") as f:
     in_install_instructions = False
     in_python_initialize_client = False
     for line in f:


### PR DESCRIPTION
Python and Java and JS all made reference to a pre grpc client. The python one is broken, and all were incompatible with the other documentation.