### PR TITLE
Corrected python code for Input Nodes section

### DIFF
--- a/api-guide/workflows/input_nodes.md
+++ b/api-guide/workflows/input_nodes.md
@@ -545,7 +545,7 @@ post_workflows_response = stub.PostWorkflows(
                             )
                         ),
                         node_inputs=[
-                            resources_pb2.NodeInput(node_id="general-concept")
+                            resources_pb2.NodeInput(node_id="general-embed")
                         ]
                     ),
                 ]

--- a/api-guide/workflows/input_nodes.md
+++ b/api-guide/workflows/input_nodes.md
@@ -73,11 +73,14 @@ post_workflows_response = stub.PostWorkflows(
                                 id="cc2074cff6dc4c02b6f4e1b8606dcb54"
                             )
                         ),
+                        node_inputs=[
+                            resources_pb2.NodeInput(node_id="general-embed")
+                        ]
                     ),
                     resources_pb2.WorkflowNode(
                         id="mapper",
                         model=resources_pb2.Model(
-                            id="synonym-model-id",
+                            id="{YOUR_SYNONYM_MODEL_ID}",
                             model_version=resources_pb2.ModelVersion(
                                 id="{YOUR_SYNONYM_MODEL_VERSION_ID}"
                             )
@@ -89,7 +92,7 @@ post_workflows_response = stub.PostWorkflows(
                     resources_pb2.WorkflowNode(
                         id="greater-than",
                         model=resources_pb2.Model(
-                            id="greater-than-model-id",
+                            id="{YOUR_GREATER_THAN_MODEL_ID}",
                             model_version=resources_pb2.ModelVersion(
                                 id="{YOUR_GREATER_THAN_MODEL_VERSION_ID}"
                             )
@@ -101,7 +104,7 @@ post_workflows_response = stub.PostWorkflows(
                     resources_pb2.WorkflowNode(
                         id="less-than",
                         model=resources_pb2.Model(
-                            id="less-than-model-id",
+                            id="{YOUR_LESS_THAN_MODEL_ID},
                             model_version=resources_pb2.ModelVersion(
                                 id="{YOUR_LESS_THAN_MODEL_VERSION_ID}"
                             )


### PR DESCRIPTION
1) Python code example in [this](https://docs.clarifai.com/api-guide/workflows/input_nodes#sample-workflow-with-multiple-connected-nodes) section is incomplete. General cluster model in the workflow has to have general embedding model's output as input. The code adds the required input node

2) The values for custom model ids and versions are inconsistent. To increase clarity for the reader, this new code sets them values following the template {YOUR_VALUE_HERE}.

3) The input node id for general cluster model in [this](https://docs.clarifai.com/api-guide/workflows/input_nodes#suppressing-the-output-from-nodes) python example is incorrect. The code sets it to a correct value.