### PR TITLE
Fix installation issues in the LlamaIndex Integration Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-error.log*
 package-lock.json
 yarn.lock
 *.lock
+.idea
+.idea

--- a/code_snippets/api-guide/integrations/llamaindex_3.py
+++ b/code_snippets/api-guide/integrations/llamaindex_3.py
@@ -19,7 +19,7 @@ PROMPT = "Hello World!"
 
 # Import the required packages
 import os
-from llama_index.embeddings import ClarifaiEmbedding
+from llama_index.embeddings.clarifai import ClarifaiEmbedding
 
 # Set Clarifai PAT as environment variable
 os.environ["CLARIFAI_PAT"] = PAT

--- a/docs/integrations/llamaindex/llm-models.md
+++ b/docs/integrations/llamaindex/llm-models.md
@@ -15,8 +15,7 @@ Let’s illustrate how you can use LlamaIndex to interact with Clarifai LLMs (la
 - Get a PAT (Personal Access Token) from the Clarifai’s portal under the [Settings/Security](https://clarifai.com/settings/security) section
 - Get the URL of the model you want to use. Large language models can be found [here](https://clarifai.com/explore/models?filterData=%5B%7B%22field%22%3A%22use_cases%22%2C%22value%22%3A%5B%22llm%22%5D%7D%5D&page=1&perPage=24)
 - Alternatively, get the ID of the user owning the model you want to use, the ID of the app where the model is found, and the name of the model
-- Install the [Clarifai Python SDK](https://docs.clarifai.com/python-sdk/sdk-overview) by running `pip install clarifai`
-- Install LlamaIndex by running `pip install llama-index`
+- Install LlamaIndex and [Clarifai Python SDK](https://docs.clarifai.com/python-sdk/sdk-overview) by running `pip install llama-index-llms-clarifai`
 
 :::info
 

--- a/docs/integrations/llamaindex/text-embeddings.md
+++ b/docs/integrations/llamaindex/text-embeddings.md
@@ -18,8 +18,7 @@ Let’s illustrate how you can use LlamaIndex to interact with Clarifai models a
 - Get a PAT (Personal Access Token) from the Clarifai’s portal under the [Settings/Security](https://clarifai.com/settings/security) section
 - Get the URL of the model you want to use. Text embedding models can be found [here](https://clarifai.com/explore/models?page=1&perPage=24&filterData=%5B%7B%22field%22%3A%22model_type_id%22%2C%22value%22%3A%5B%22text-embedder%22%5D%7D%5D)
 - Alternatively, get the ID of the user owning the model you want to use, the ID of the app where the model is found, and the name of the model
-- Install the [Clarifai Python SDK](https://docs.clarifai.com/python-sdk/sdk-overview) by running `pip install clarifai`
-- Install LlamaIndex by running `pip install llama-index`
+- Install LlamaIndex and [Clarifai Python SDK](https://docs.clarifai.com/python-sdk/sdk-overview) by running `pip install llama-index-embeddings-clarifai`
 
 :::info
 


### PR DESCRIPTION
1. In the LlamaIndex documentation under [LLMs](https://docs.clarifai.com/integrations/llamaindex/llm-models), we currently mention installing `pip install clarifai` and `pip install llama-index`. However, we need to install `llama-index-llms-clarifai`, which installs both llama-index and clarifai along with other dependencies, otherwise it throws a "no module found" error when importing the libraries. 
2. The same applies to the embedding models; we need to install `llama-index-embeddings-clarifai` 
3. And while importing the `ClarifaiEmbedding` we need to import it from `llama_index.embeddings.clarifai ` instead of `llama_index.embeddings`.