### PR TITLE
feat: created open-ai interfaces examples for js

### DIFF
--- a/code_snippets/python-sdk/compute-orchestration/openai_1.ts
+++ b/code_snippets/python-sdk/compute-orchestration/openai_1.ts
@@ -1,0 +1,16 @@
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://api.clarifai.com/v2/ext/openai/v1",
+  apiKey: process.env.CLARIFAI_PAT,
+});
+
+const response = await client.chat.completions.create({
+  model: "https://clarifai.com/openai/chat-completion/models/gpt-4o",
+  messages: [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "Who are you?" },
+  ],
+});
+
+console.log(response.choices?.[0]?.message.content);

--- a/code_snippets/python-sdk/compute-orchestration/openai_2.ts
+++ b/code_snippets/python-sdk/compute-orchestration/openai_2.ts
@@ -1,0 +1,40 @@
+import OpenAI from "openai";
+import type { ChatCompletionTool } from "openai/resources";
+
+const client = new OpenAI({
+  baseURL: "https://api.clarifai.com/v2/ext/openai/v1",
+  apiKey: process.env.CLARIFAI_PAT,
+});
+
+const tools: ChatCompletionTool[] = [
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Get current temperature for a given location.",
+      parameters: {
+        type: "object",
+        properties: {
+          location: {
+            type: "string",
+            description: "City and country e.g. Bogotá, Colombia",
+          },
+        },
+        required: ["location"],
+        additionalProperties: false,
+      },
+      strict: true,
+    },
+  },
+];
+
+const toolCompletion = await client.chat.completions.create({
+  model: "https://clarifai.com/openai/chat-completion/models/gpt-4o",
+  messages: [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "What is the weather in New York?" },
+  ],
+  tools,
+});
+
+console.log(toolCompletion.choices?.[0]?.message.tool_calls);

--- a/docs/compute/models/inference/open-ai.md
+++ b/docs/compute/models/inference/open-ai.md
@@ -4,16 +4,16 @@ sidebar_position: 1.1
 toc_max_heading_level: 4
 ---
 
-# OpenAI Inferences 
+# OpenAI Inferences
 
 **Make inferences with Clarifai using an OpenAI-compatible format**
 <hr />
 
-Clarifai provides an OpenAI-compatible API endpoint, which allows you to leverage your existing OpenAI API code and workflows to make inferences with Clarifai models, including those that integrate or wrap OpenAI models. 
+Clarifai provides an OpenAI-compatible API endpoint, which allows you to leverage your existing OpenAI API code and workflows to make inferences with Clarifai models, including those that integrate or wrap OpenAI models.
 
 The built-in compatibility layer converts your OpenAI calls directly into Clarifai API requests, letting you harness Clarifai's diverse models as custom tools in your OpenAI projects.
 
-This simplifies the integration process, as you don't need to rewrite your code specifically for Clarifai's native API structure if you're already familiar with OpenAI's. 
+This simplifies the integration process, as you don't need to rewrite your code specifically for Clarifai's native API structure if you're already familiar with OpenAI's.
 
 > **Note** Usage-based billing is handled directly through Clarifai — not through OpenAI or any other external tool. Also, while most OpenAI parameters are supported, certain advanced features may be unavailable depending on the specific model or endpoint.
 
@@ -24,7 +24,9 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from "@theme/CodeBlock";
 
 import Example1 from "!!raw-loader!../../../../code_snippets/python-sdk/compute-orchestration/openai_1.py";
+import TSExample1 from "!!raw-loader!../../../../code_snippets/python-sdk/compute-orchestration/openai_1.ts";
 import Example2 from "!!raw-loader!../../../../code_snippets/python-sdk/compute-orchestration/openai_2.py";
+import TSExample2 from "!!raw-loader!../../../../code_snippets/python-sdk/compute-orchestration/openai_2.ts";
 import Example3 from "!!raw-loader!../../../../code_snippets/python-sdk/compute-orchestration/openai_3.py";
 import Example4 from "!!raw-loader!../../../../code_snippets/python-sdk/compute-orchestration/openai_4.txt";
 
@@ -47,15 +49,18 @@ Install the latest version of the Clarifai [Python](https://github.com/Clarifai/
 
 #### Get a PAT Key
 
-You need a PAT (Personal Access Token) key to authenticate your connection to the Clarifai platform. You can generate the PAT key in your personal settings page by navigating to the [Security section](https://clarifai.com/settings/security). 
+You need a PAT (Personal Access Token) key to authenticate your connection to the Clarifai platform. You can generate the PAT key in your personal settings page by navigating to the [Security section](https://clarifai.com/settings/security).
 
 #### Install Openai Package
 
 Install the `openai` package:
 
 <Tabs>
-<TabItem value="bash" label="Bash">
+<TabItem value="python" label="Python">
     <CodeBlock className="language-bash"> pip install openai </CodeBlock>
+</TabItem>
+<TabItem value="node.js" label="Node.js">
+    <CodeBlock className="language-bash"> npm install openai </CodeBlock>
 </TabItem>
 </Tabs>
 
@@ -67,6 +72,9 @@ Here is an example that uses the OpenAI Python client library to interact with a
 <TabItem value="python" label="Python SDK">
     <CodeBlock className="language-python">{Example1}</CodeBlock>
 </TabItem>
+<TabItem value="typescript" label="TypeScript">
+    <CodeBlock className="language-typescript">{TSExample1}</CodeBlock>
+</TabItem>
 </Tabs>
 
 <details>
@@ -77,15 +85,18 @@ I'm Claude, an AI assistant created by Anthropic. I'm here to help with a wide v
 
 ### Tool Calling
 
-Tool calling (formerly known as function calling) enables large language models (LLMs) to autonomously decide when and how to invoke external tools — such as APIs or custom functions — based on user input. 
+Tool calling (formerly known as function calling) enables large language models (LLMs) to autonomously decide when and how to invoke external tools — such as APIs or custom functions — based on user input.
 
-With Clarifai’s support for OpenAI-compatible APIs, you can seamlessly integrate tool-calling capabilities using your existing OpenAI workflows, while leveraging Clarifai-hosted or custom models. 
+With Clarifai’s support for OpenAI-compatible APIs, you can seamlessly integrate tool-calling capabilities using your existing OpenAI workflows, while leveraging Clarifai-hosted or custom models.
 
 Here is an example code that sets up a basic tool-calling interaction. It simulates a weather API and shows how the LLM would "call" that tool when asked about the weather.
 
 <Tabs>
 <TabItem value="python" label="Python SDK">
     <CodeBlock className="language-python">{Example2}</CodeBlock>
+</TabItem>
+<TabItem value="typescript" label="TypeScript">
+    <CodeBlock className="language-typescript">{TSExample2}</CodeBlock>
 </TabItem>
 </Tabs>
 
@@ -95,7 +106,7 @@ Here is an example code that sets up a basic tool-calling interaction. It simula
     <CodeBlock className="language-text">{Example4}</CodeBlock>
 </details>
 
-## LiteLLM 
+## LiteLLM
 
 You can use the [LiteLLM Python SDK](https://github.com/BerriAI/litellm) to directly route inference requests to their Clarifai-hosted models. This provides a lightweight, OpenAI-compatible interface for interacting with Clarifai's powerful LLMs using a single, unified API.
 


### PR DESCRIPTION
This pull request introduces TypeScript examples for interacting with the OpenAI API and updates the documentation to include these examples alongside Python examples. The most important changes include adding TypeScript code snippets for basic chat completions and tool-calling interactions, as well as updating the documentation to reflect these additions.

### Code additions for TypeScript examples:
* Added a TypeScript example (`code_snippets/python-sdk/compute-orchestration/openai_1.ts`) demonstrating basic chat completions using the OpenAI API.
* Added a TypeScript example (`code_snippets/python-sdk/compute-orchestration/openai_2.ts`) showcasing tool-calling interactions with the OpenAI API.

### Documentation updates:
* Updated `docs/compute/models/inference/open-ai.md` to include TypeScript code snippets (`TSExample1` and `TSExample2`) alongside Python examples for both basic chat completions and tool-calling interactions. [[1]](diffhunk://#diff-be36873192a084dc4e82539f36102c01fcb645126791e28da480b4b1cb8b4b8fR27-R29) [[2]](diffhunk://#diff-be36873192a084dc4e82539f36102c01fcb645126791e28da480b4b1cb8b4b8fR75-R77) [[3]](diffhunk://#diff-be36873192a084dc4e82539f36102c01fcb645126791e28da480b4b1cb8b4b8fR98-R100)
* Added installation instructions for the OpenAI package in Node.js (`npm install openai`) to the documentation.