### PR TITLE
docs: updated vercel ai sdk support

### DIFF
--- a/code_snippets/python-sdk/compute-orchestration/vercel_1.ts
+++ b/code_snippets/python-sdk/compute-orchestration/vercel_1.ts
@@ -1,12 +1,12 @@
-import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText } from "ai";
 
-const openai = createOpenAI({
+const clarifai = createOpenAICompatible({
   baseURL: "https://api.clarifai.com/v2/ext/openai/v1",
   apiKey: process.env.CLARIFAI_PAT,
 });
 
-const model = openai(
+const model = clarifai(
   "https://clarifai.com/anthropic/completion/models/claude-sonnet-4",
 );
 

--- a/code_snippets/python-sdk/compute-orchestration/vercel_2.ts
+++ b/code_snippets/python-sdk/compute-orchestration/vercel_2.ts
@@ -1,12 +1,12 @@
-import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { streamText } from "ai";
 
-const openai = createOpenAI({
+const clarifai = createOpenAICompatible({
   baseURL: "https://api.clarifai.com/v2/ext/openai/v1",
   apiKey: process.env.CLARIFAI_PAT,
 });
 
-const model = openai(
+const model = clarifai(
   "https://clarifai.com/anthropic/completion/models/claude-sonnet-4",
 );
 

--- a/code_snippets/python-sdk/compute-orchestration/vercel_3.ts
+++ b/code_snippets/python-sdk/compute-orchestration/vercel_3.ts
@@ -1,13 +1,13 @@
-import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText, tool } from "ai";
 import { z } from "zod";
 
-const openai = createOpenAI({
+const clarifai = createOpenAICompatible({
   baseURL: "https://api.clarifai.com/v2/ext/openai/v1",
   apiKey: process.env.CLARIFAI_PAT,
 });
 
-const model = openai(
+const model = clarifai(
   "https://clarifai.com/anthropic/completion/models/claude-sonnet-4",
 );
 

--- a/docs/compute/models/inference/open-ai.md
+++ b/docs/compute/models/inference/open-ai.md
@@ -124,7 +124,7 @@ Here is an example code that sets up a basic tool-calling interaction. It simula
 
 ## Vercel AI SDK
 
-The [Vercel AI SDK](https://vercel.com/docs/ai-sdk) provides a convenient way to interact with Clarifai's OpenAI-compatible API. You can leverage the [OpenAI provider](https://ai-sdk.dev/providers/ai-sdk-providers/openai) to interact with Clarifai models.
+The [Vercel AI SDK](https://vercel.com/docs/ai-sdk) provides a convenient way to interact with Clarifai's OpenAI-compatible API. You can leverage the [@ai-sdk/openai-compatible](https://www.npmjs.com/package/@ai-sdk/openai-compatible) to interact with Clarifai models.
 
 ### Example
 <Tabs>

--- a/docs/compute/models/inference/open-ai.md
+++ b/docs/compute/models/inference/open-ai.md
@@ -139,6 +139,39 @@ The [Vercel AI SDK](https://vercel.com/docs/ai-sdk) provides a convenient way to
     </TabItem>
 </Tabs>
 
+<details>
+    <summary>Vercel AI SDK model capabilities list</summary>
+    | Model | Image Input | Tool Usage | Tool Streaming |
+    | --- | --- | --- | --- |
+    | [DeepSeek R1 0528 Qwen3 8B](https://clarifai.com/deepseek-ai/deepseek-chat/models/DeepSeek-R1-0528-Qwen3-8B) | ✅ | ✅ | ✅ |
+    | [Llama 3.2 3B Instruct](https://clarifai.com/meta/Llama-3/models/Llama-3_2-3B-Instruct) | ✅ | ✅ | ✅ |
+    | [claude Sonnet 4](https://clarifai.com/anthropic/completion/models/claude-sonnet-4) | ✅ | ✅ | ✅ |
+    | [Qwen3 14B](https://clarifai.com/qwen/qwenLM/models/Qwen3-14B) | ✅ | ✅ | ✅ |
+    | [Devstral Small 2505.gguf 4bit](https://clarifai.com/mistralai/completion/models/Devstral-Small-2505_gguf-4bit) | ✅ | ✅ | ✅ |
+    | [grok 3](https://clarifai.com/xai/chat-completion/models/grok-3) | ❌ | ✅ | ✅ |
+    | [gpt 4o](https://clarifai.com/openai/chat-completion/models/gpt-4o) | ✅ | ✅ | ✅ |
+    | [gpt 4.1](https://clarifai.com/openai/chat-completion/models/gpt-4_1) | ✅ | ✅ | ✅ |
+    | [gemini 2.5 Flash](https://clarifai.com/gcp/generate/models/gemini-2_5-flash) | ✅ | ✅ | ✅ |
+    | [claude 3.5 Haiku](https://clarifai.com/anthropic/completion/models/claude-3_5-haiku) | ✅ | ✅ | ✅ |
+    | [Qwen3 30B A3B GGUF](https://clarifai.com/qwen/qwenLM/models/Qwen3-30B-A3B-GGUF) | ✅ | ✅ | ✅ |
+    | [gemini 2.0 Flash](https://clarifai.com/gcp/generate/models/gemini-2_0-flash) | ✅ | ✅ | ✅ |
+    | [gemma 3 12b It](https://clarifai.com/gcp/generate/models/gemma-3-12b-it) | ✅ | ✅ | ✅ |
+    | [Phi 4 Reasoning Plus](https://clarifai.com/microsoft/text-generation/models/Phi-4-reasoning-plus) | ✅ | ✅ | ✅ |
+    | [phi 4 Mini Instruct](https://clarifai.com/microsoft/text-generation/models/phi-4-mini-instruct) | ✅ | ✅ | ✅ |
+    | [Qwen2.5 VL 7B Instruct](https://clarifai.com/qwen/qwen-VL/models/Qwen2_5-VL-7B-Instruct) | ✅ | ❌ | ❌ |
+    | [phi 4](https://clarifai.com/microsoft/text-generation/models/phi-4) | ✅ | ✅ | ✅ |
+    | [grok 2 Vision 1212](https://clarifai.com/xai/chat-completion/models/grok-2-vision-1212) | ✅ | ✅ | ✅ |
+    | [grok 2 1212](https://clarifai.com/xai/chat-completion/models/grok-2-1212) | ❌ | ✅ | ✅ |
+    | [QwQ 32B AWQ](https://clarifai.com/qwen/qwenLM/models/QwQ-32B-AWQ) | ✅ | ✅ | ✅ |
+    | [gemini 2.0 Flash Lite](https://clarifai.com/gcp/generate/models/gemini-2_0-flash-lite) | ✅ | ✅ | ✅ |
+    | [claude Opus 4](https://clarifai.com/anthropic/completion/models/claude-opus-4) | ✅ | ✅ | ✅ |
+    | [o4 Mini](https://clarifai.com/openai/chat-completion/models/o4-mini) | ✅ | ✅ | ✅ |
+    | [o3](https://clarifai.com/openai/chat-completion/models/o3) | ✅ | ✅ | ✅ |
+    | [MiniCPM-o 2.6 Language](https://clarifai.com/openbmb/miniCPM/models/MiniCPM-o-2_6-language) | ✅ | ❌ | ❌ |
+    | [DeepSeek R1 Distill Qwen 7B](https://clarifai.com/deepseek-ai/deepseek-chat/models/DeepSeek-R1-Distill-Qwen-7B) | ✅ | ❌ | ❌ |
+    | [Qwen2.5 Coder 7B Instruct](https://clarifai.com/qwen/qwenCoder/models/Qwen2_5-Coder-7B-Instruct) | ✅ | ✅ | ✅ |
+</details>
+
 ## LiteLLM
 
 You can use the [LiteLLM Python SDK](https://github.com/BerriAI/litellm) to directly route inference requests to their Clarifai-hosted models. This provides a lightweight, OpenAI-compatible interface for interacting with Clarifai's powerful LLMs using a single, unified API.


### PR DESCRIPTION
This pull request updates the Vercel AI SDK integration to use the `@ai-sdk/openai-compatible` package for interacting with Clarifai's OpenAI-compatible API. Additionally, it enhances the documentation with updated references and a detailed capabilities list for supported models.

### Updates to SDK integration:

* Replaced `createOpenAI` with `createOpenAICompatible` in `code_snippets/python-sdk/compute-orchestration` files to align with the `@ai-sdk/openai-compatible` package. This includes changes to the initialization of the Clarifai client and the model configuration. [[1]](diffhunk://#diff-4a2366d4e0485f717ab435dfa2a1617dfa06149a82a4a306e2e5985af80e91bfL1-R9) [[2]](diffhunk://#diff-175a7771c27580231276340f373e6ca4a82408711201f651178c1930df6306c1L1-R9) [[3]](diffhunk://#diff-66ca41c04d76e9dd902de22f780e3c9d000be89e17e9b81beb64c7d3ba7e6d8bL1-R10)

### Documentation improvements:

* Updated the documentation in `docs/compute/models/inference/open-ai.md` to reference the `@ai-sdk/openai-compatible` package instead of the OpenAI provider.
* Added a detailed capabilities list for Clarifai-supported models in the documentation, showcasing features like image input, tool usage, and tool streaming.