### PR TITLE
PR-754 update installation documentation for clarifai-python

### DIFF
--- a/docs/resources/api-overview/python-sdk.md
+++ b/docs/resources/api-overview/python-sdk.md
@@ -47,8 +47,7 @@ git clone https://github.com/Clarifai/clarifai-python.git
 cd clarifai-python
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
-python setup.py install
+pip install -e .
 ```
 
 ## Authentication

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -38977,8 +38977,7 @@ git clone https://github.com/Clarifai/clarifai-python.git
 cd clarifai-python
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
-python setup.py install
+pip install -e .
 ```
 
 ## Authentication


### PR DESCRIPTION
Our documentation extensively references `python setup.py xxx` commands for clarifai-python which have been deprecated since 2020 and fail on modern systems, causing setup issues for users and contributors. This PR updates it with `pip install -e .` equivalents. 

The same change is brought to clarifai-python repo in this PR https://github.com/Clarifai/clarifai-python/pull/737 

@Alfrick This is the first time I try to make an small change in this repo and I am not sure what I should do for `llms.txt`, please let me know if anything to correct.