### PR TITLE
Add CLI-first deployment guide

### DIFF
--- a/docs/getting-started/first-deployment-cli.md
+++ b/docs/getting-started/first-deployment-cli.md
@@ -1,0 +1,96 @@
+---
+description: Deploy a model to Clarifai cloud compute using the CLI
+sidebar_position: 3
+---
+
+# Deploy Your First Model via CLI
+
+**From zero to a running model in minutes**
+<hr />
+
+Clarifai's CLI gives you a fast, code-first path to deploy any HuggingFace model to cloud compute — with local testing built in before you spend a dollar on GPU time.
+
+## Prerequisites
+
+Install the Clarifai Python package and log in:
+
+```sh
+pip install clarifai
+clarifai login
+```
+
+## Step 1: Initialize the model
+
+Scaffold a model project using vLLM and a HuggingFace model name:
+
+```sh
+clarifai model init --toolkit vllm --model-name Qwen/Qwen3-4B
+```
+
+This creates a local directory (`./Qwen3-4B`) with a `config.yaml`, `requirements.txt`, and `1/model.py` pre-configured for vLLM.
+
+## Step 2: Test locally
+
+Run the model locally before deploying to cloud compute:
+
+```sh
+clarifai model serve ./Qwen3-4B --mode env
+```
+
+The `--mode env` flag creates an isolated virtual environment for the model's dependencies, avoiding conflicts with your existing Python packages.
+
+:::note
+`clarifai model serve` runs the model on your local machine. If your machine does not have a GPU, or doesn't meet the model's memory requirements, skip to [Step 3](#step-3-deploy-to-cloud) and deploy directly to a cloud GPU instead.
+:::
+
+:::tip
+The first run downloads the model weights from HuggingFace (~7.7 GB for Qwen3-4B). Set `HF_TOKEN` in your environment for faster, authenticated downloads:
+```sh
+export HF_TOKEN=your_token_here
+```
+:::
+
+When the model is ready, the CLI displays:
+- The model URL on Clarifai
+- A Playground link to test it in the browser
+- The exact `clarifai model predict` command to run inference
+
+Press `Ctrl+C` to stop the local server when you're done testing.
+
+## Step 3: Deploy to cloud
+
+Deploy the model to dedicated cloud compute:
+
+```sh
+clarifai model deploy ./Qwen3-4B --instance gpu-nvidia-a10g
+```
+
+To see all available instance types and pricing before choosing:
+
+```sh
+clarifai model deploy --instance-info
+```
+
+Clarifai automatically provisions a compute cluster and nodepool if one doesn't already exist.
+
+## Step 4: Stream logs
+
+Stream logs from the runner to confirm the model loaded successfully:
+
+```sh
+clarifai model logs --model-url YOUR_MODEL_URL
+```
+
+Replace `YOUR_MODEL_URL` with the model URL printed by the deploy command (e.g. `https://clarifai.com/YOUR_USER_ID/main/models/qwen3-4b`).
+
+## Step 5: Run inference
+
+Send a prediction to your deployed model:
+
+```sh
+clarifai model predict YOUR_MODEL_URL "Explain quantum computing in one sentence"
+```
+
+---
+
+Prefer the UI? See [Deploy a Model](https://docs.clarifai.com/compute/deployments/deploy-model) for a step-by-step walkthrough using the Clarifai platform.

--- a/docs/getting-started/first-deployment.md
+++ b/docs/getting-started/first-deployment.md
@@ -1,14 +1,14 @@
 ---
 description: Set up your computing infrastructure easily and fast for inference
-sidebar_position: 3
+sidebar_position: 4
 ---
 
-# Deploy Your First Model
+# Deploy Your First Model via UI
 
 **Quickly set up infrastructure for inference**
 <hr />
 
-Clarifai provides an intuitive interface that makes it easy to provision compute infrastructure for running your models. 
+Clarifai provides an intuitive interface that makes it easy to provision compute infrastructure for running your models.
 
 [Deployment](https://docs.clarifai.com/compute/deployments/deploy-model) allows you to configure and activate the infrastructure needed to serve model predictions. With just a few simple steps, you can deploy a trained model and start generating predictions.
 


### PR DESCRIPTION
## Summary
- Adds `first-deployment-cli.md`: a developer-first step-by-step guide using `clarifai model init → serve → deploy` with Qwen3-4B
- Renames `first-deployment.md` to "Deploy Your First Model via UI" and bumps to `sidebar_position: 4`
- CLI page sits at `sidebar_position: 3` as the primary path for developers

## Notes
- Page is drafted but not ready to merge yet — CLI features are still being tested in the `cli-improvement` branch and will ship tomorrow
- Includes `--mode env` tip for dependency isolation and a note to skip `serve` if no local GPU

## Test plan
- [ ] Verify sidebar order: CLI guide appears before UI guide in Getting Started
- [ ] Confirm all CLI commands match the final production release of `clarifai model deploy`, `serve`, `logs`, `predict`
- [ ] Update with real example output once CLI is in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)