### PR TITLE
Update compute docs and add CLAUDE.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ package-lock.json
 # log files
 *.log
 .claude/worktrees/
+CLAUDE.md

--- a/docs/compute/agents/deploy-mcp.md
+++ b/docs/compute/agents/deploy-mcp.md
@@ -53,6 +53,8 @@ With MCP server integration, an agentic model can iteratively discover tools, ex
 > * Compatibility with the OpenAI-compatible API and Clarifai SDKs
 > * Support for both streaming and non-streaming modes
 >
+> The `AgenticModelClass` manages the full agentic loop: it discovers available MCP tools at model load time, injects them into the LLM context, and iteratively calls tools and feeds results back to the model until a final response is produced.
+>
 > You can see an example implementation of `AgenticModelClass` in [this `1/model.py`](https://github.com/Clarifai/runners-examples/blob/main/llm/agentic-gpt-oss-20b/1/model.py) file.
 
 :::tip
@@ -164,10 +166,12 @@ The `StdioMCPModelClass` abstracts away the complexity of managing stdio-based M
 
 Specifically, `StdioMCPModelClass` automatically:
 
-* Starts the MCP server as a stdio process
-* Discovers all available MCP tools
+* Starts the MCP server as a single long-lived stdio process (e.g., a Node.js or Python subprocess) during `load_model()`
+* Opens a persistent FastMCP client session that is reused for all subsequent requests, reducing per-request overhead
+* Discovers all available MCP tools at startup
 * Exposes the tools through an HTTP API
 * Handles tool execution and response formatting
+* Supports configuration via YAML, including environment variables and injected secrets
 
 This makes it easy to deploy open-source MCP servers on Clarifai with minimal code.
 

--- a/docs/compute/agents/mcp.md
+++ b/docs/compute/agents/mcp.md
@@ -165,6 +165,13 @@ You must define it by subclassing Clarifai's `MCPModelClass` and implementing th
 
 When Clarifai runs the model, it calls `get_server()` to load your MCP server and expose its defined tools and capabilities to LLMs or other agents.
 
+:::tip Alternative MCP base classes
+
+- **`StdioMCPModelClass`** — Use this when wrapping an existing stdio-based MCP server (e.g., an open-source server launched as a subprocess). See [Deploy Open-Source MCP Servers](deploy-mcp.md) for a full walkthrough.
+- **`AgenticModelClass`** — Use this when building an LLM-based model that should autonomously discover and call MCP tools during inference. See the agentic model section in [Deploy Open-Source MCP Servers](deploy-mcp.md#get-an-agentic-model) for details.
+
+:::
+
 ### Step 3: Prepare `config.yaml` File
 
 The `config.yaml` file is used to configure the build and deployment settings for a custom model on the Clarifai platform. It tells Clarifai how to build your model's environment and where to place it within your account.

--- a/docs/compute/inference/open-ai.md
+++ b/docs/compute/inference/open-ai.md
@@ -193,6 +193,12 @@ The following example demonstrates a simple tool-calling interaction. It simulat
 
 The [OpenAI Chat Completions](https://platform.openai.com/docs/api-reference/chat) API endpoint enables you to generate a model response by providing a list of messages that constitute a conversation.
 
+:::note Supported Message Roles
+
+Clarifai's LLM endpoint supports the following message roles: `system`, `user`, `assistant`, `developer`, and `tool`. The `developer` role is used for developer-level instructions (similar to `system`), while `tool` is used for passing back the results of tool calls during agentic interactions.
+
+:::
+
 ### Text Inputs
 
 <Tabs groupId="code">

--- a/docs/compute/local-runners/README.mdx
+++ b/docs/compute/local-runners/README.mdx
@@ -231,6 +231,9 @@ Or with a specific model path:
 | `--port` | 8000 | Server port (with `--grpc`) |
 | `--concurrency` | 32 | Max concurrent requests (equivalent to `--pool_size`) |
 | `--keep-image` | off | Keep Docker image after exit (container mode only) |
+| `--health-check-port` | auto | Port for the health check HTTP server |
+| `--disable-health-check` | off | Disable the health check server entirely |
+| `--auto-find-health-check-port` | off | Automatically find an available port if the default is in use |
 | `-v, --verbose` | off | Show detailed logs (useful for debugging toolkit servers like [Ollama](https://docs.clarifai.com/compute/toolkits/ollama/)) |
 
 :::

--- a/docs/compute/pipelines/create-api.md
+++ b/docs/compute/pipelines/create-api.md
@@ -78,9 +78,10 @@ Run the following command to create a new pipeline project in your current direc
 </TabItem>
 </Tabs>
 
-> **Note:** 
+> **Note:**
 > - You can initialize a project in a specific location by providing a `PIPELINE_PATH`. For example, running `clarifai pipeline init <pipeline-name>` creates a new directory named `<pipeline-name>` and populates it with all the required pipeline project files.
 > - You can shorten `pipeline` to `pl` when running pipeline commands. For example: `clarifai pl init`.
+> - By default, `clarifai pipeline init` fetches templates from the official Clarifai pipeline templates repository. To point to a custom or private template repository, set the `CLARIFAI_PIPELINE_TEMPLATES_GIT_REPO_URL` environment variable to your repository URL before running the command.
 
 After running the command, you’ll be prompted to provide the following details:
 
@@ -187,6 +188,8 @@ This section tells Clarifai which folders in your project represent pipeline ste
 The execution order is stipulated by the Argo Workflow Definition, as explained below.
 
 Each listed directory corresponds to one pipeline step created during initialization. As mentioned [earlier](#pipeline-steps), each step contains its own `config.yaml`, `requirements.txt`, and executable logic, allowing steps to be configured and maintained independently.
+
+> **Note:** `step_directories` is optional when all `templateRef` entries in the Argo Workflow Definition already include a pinned version ID. In that case, Clarifai resolves the step implementations directly from those versioned references and does not need to upload local step directories. This is useful when the pipeline steps are already deployed to the platform and you only need to update or re-upload the pipeline definition itself.
 
 #### Argo Workflow Definition
 

--- a/docs/compute/upload/README.mdx
+++ b/docs/compute/upload/README.mdx
@@ -276,6 +276,7 @@ These are some parameters you can define:
 - **`num_accelerators`** – Number of GPUs or TPUs to use for inference.
 - **`accelerator_type`** – Specifies the type of hardware [accelerators](https://docs.clarifai.com/compute/cloud-instances/) (e.g., GPU or TPU) supported by the model (e.g., "NVIDIA-A10G"). _Note that instead of specifying an exact accelerator type, you can use a wildcard `(*)` to automatically match all available accelerators that fit your use case. For example, using `["NVIDIA-*"]` will enable the system to choose from all NVIDIA options compatible with your model._
 - **`accelerator_memory`** – Minimum memory required for the GPU or TPU.
+- **`num_threads`** – Number of threads allocated to the model runner container. Useful for CPU-bound models where controlling thread concurrency improves performance or prevents resource contention.
 
 #### Hugging Face Model Checkpoints  
 
@@ -312,15 +313,17 @@ Downloading checkpoints at `build` or `upload` time can significantly increase i
 
 #### Model Concepts or Labels
 
-This section is required if your model outputs concepts or labels and is not being directly loaded from Hugging Face. So, you must define a `concepts` section in the `config.yaml` file. 
+This section is required if your model outputs concepts or labels and is not being directly loaded from Hugging Face. So, you must define a `concepts` section in the `config.yaml` file.
 
 The following model types output concepts or labels:
 
 - `visual-classifier`
 - `visual-detector`
 - `visual-segmenter`
-- `text-classifier` 
+- `text-classifier`
 - `visual-keypointer`
+
+> **Note:** For `visual-classifier` and `visual-detector` models, you can now specify explicit concept IDs in `config.yaml` in addition to concept names. When concept IDs are defined, the platform uses them directly instead of auto-generating IDs from names. This ensures the concept IDs in your model's `output_info` match those returned in prediction outputs, preventing ID mismatches.
 
 <Tabs groupId="code">
 <TabItem value="yaml" label="YAML">

--- a/docs/resources/api-overview/cli.md
+++ b/docs/resources/api-overview/cli.md
@@ -720,6 +720,15 @@ Here is how you can open the configuration file of your current context for edit
 
 The `env` (or `get-env`) subcommand prints the environment variables that correspond to your active Clarifai context. It’s useful if you want to export these variables for use in other tools, scripts, or terminals.
 
+The context stores the following variables:
+
+| Variable | Description |
+|----------|-------------|
+| `CLARIFAI_API_BASE` | Base API URL (default: `https://api.clarifai.com`) |
+| `CLARIFAI_PAT` | Personal Access Token for authentication |
+| `CLARIFAI_USER_ID` | Your Clarifai user ID |
+| `CLARIFAI_HF_TOKEN` | Hugging Face access token for downloading gated or private model checkpoints |
+
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
    
@@ -764,6 +773,7 @@ clarifai config env
 export CLARIFAI_API_BASE="https://api.clarifai.com"
 export CLARIFAI_PAT="XXXX"
 export CLARIFAI_USER_ID="XXXX"
+export CLARIFAI_HF_TOKEN="XXXX"
 ```
 </details>
 
@@ -1141,6 +1151,8 @@ The `clarifai model init` command scaffolds a new Clarifai model project. The re
 
 If `MODEL_PATH` is not provided, the current directory is used. When `--model-name` is provided, a directory is automatically created using the model name.
 
+> **Note:** Running `clarifai model init` inside an existing model directory updates the files in place rather than creating a new subdirectory. This means you can safely re-run the command to refresh generated files without duplicating your project structure.
+
 ### Initialize With Toolkit (Recommended)
 
 The `--toolkit` flag selects a pre-configured inference framework. Combined with `--model-name`, this is the fastest way to get a model ready for local serving or cloud deployment.
@@ -1338,6 +1350,9 @@ clarifai model serve ./my-model --grpc --port 9000
 | `--port` | 8000 | Server port (with `--grpc`) |
 | `--concurrency` | 32 | Max concurrent requests |
 | `--keep-image` | off | Keep Docker image after exit (container mode) |
+| `--health-check-port` | auto | Port for the health check HTTP server |
+| `--disable-health-check` | off | Disable the health check server entirely |
+| `--auto-find-health-check-port` | off | Automatically find an available port if the default is in use |
 | `-v, --verbose` | off | Show detailed logs |
 
 ### How It Works


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` to `.gitignore`
- Add `AgenticModelClass` and `StdioMCPModelClass` details to MCP deploy docs
- Add alternative MCP base classes tip to `mcp.md`
- Add supported message roles note to `open-ai.md`
- Add health-check flags (`--health-check-port`, `--disable-health-check`, `--auto-find-health-check-port`) to local-runners and CLI docs
- Add `num_threads` param and concept ID note to upload docs
- Add pipeline template env var and `step_directories` note to pipelines docs
- Add `CLARIFAI_HF_TOKEN` to CLI context env vars table

## Test plan

- [ ] Verify all internal links resolve correctly (no broken links)
- [ ] Review rendered output for new notes/tips/tables
- [ ] Confirm `CLAUDE.md` is no longer tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)