### PR TITLE
Update Postman docs and collection URL

### DIFF
--- a/docs/resources/api-references/postman.md
+++ b/docs/resources/api-references/postman.md
@@ -3,73 +3,142 @@ description: Learn how to use Postman with Clarifai APIs
 sidebar_position: 3
 ---
 
-# Postman 
+# Postman
 
 **Learn how to use Postman with Clarifai APIs**
 <hr />
 
-This page explains how to use [Postman](https://www.postman.com/) to perform some API calls to Clarifai by showing the actions available within the Clarifai platform. You can use Postman to make a wide variety of `GET`, `POST`, `PATCH`, and `DELETE` calls.
+[Postman](https://www.postman.com/) is a popular API client that lets you explore, test, and interact with REST APIs without writing any code. 
 
-With Postman, you can use, hit, or test the Clarifai API without the need to use the Portal or call the endpoints programmatically. Postman also allows you to make API calls and generate code snippets in your favorite programming language. You can use the snippets to make REST requests to the Clarifai API.
+The Clarifai Postman collection gives you instant access to various endpoints across different resource areas — applications, inputs, models, workflows, datasets, search, compute orchestration, and more — with pre-configured authentication and ready-to-use request bodies.
 
-This page will hopefully get you set up and somewhat familiar with using Postman to make requests to the Clarifai platform. After learning how to use Postman to make calls to Clarifai, you can make other requests by referring to the REST examples throughout this documentation. 
+:::tip Access Postman collection
+
+You can access the Clarifai Postman collection [here](https://documenter.getpostman.com/view/24309294/2sBXijHWuM).
+
+:::
 
 ## Prerequisites
--  An active Clarifai account
--  Basic knowledge of an API structure and JSON formatting
 
-## Postman Basics
-By clicking the **Send** button , you can receive the response for a particular request you created or selected from the collection. 
+- An active [Clarifai account](https://clarifai.com/signup)
+- [Postman](https://www.postman.com/downloads/) desktop app or access to [Postman Web](https://web.postman.com/)
+- A Personal Access Token (PAT) — see [Step 2](#step-2-get-your-pat) below
 
-![Alt text](/img/postman/image-2.png)
+## What's in the Collection
+
+The collection is organized into the following folders:
+
+| Folder | Description |
+| --- | --- |
+| **Applications** | Create and manage apps |
+| **Annotations** | Label inputs and manage annotation filters |
+| **Collectors** | Auto-capture inputs from external model calls |
+| **Concepts** | Manage labels, vocabularies, and concept graphs |
+| **Datasets** | Create datasets, add inputs, and version snapshots |
+| **Inputs** | Upload images, video, text, and audio |
+| **Models** | Create, train, evaluate, predict, and export models |
+| **Search** | Rank by visual similarity and filter by concept or region |
+| **Workflows** | Chain models into multi-step inference pipelines |
+| **Pipelines** | Orchestrate multi-step data processing runs |
+| **Artifacts** | Store and version model weights and config files |
+| **Secrets** | Manage credentials for compute infrastructure |
+| **Runners** | Register agents for on-premises model inference |
+| **Compute Orchestration** | Provision clusters, nodepools, and model deployments |
+| **Walkthroughs** | End-to-end guides (RAG, visual classifier, and more) |
 
 ## Getting Started
 
-Follow the steps below to start using Postman with Clarifai APIs.
+### Step 1: Import the Collection
 
-### Step 1: Fork Your Postman Collection
+Click the button below to fork the Clarifai Postman collection directly into your workspace.
 
-Click the button below to fork the Clarifai Postman collection to your workspace.
 <br/>
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/30622694-ddd58eb6-5c51-42a3-aa0d-97cc0efd546d?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D30622694-ddd58eb6-5c51-42a3-aa0d-97cc0efd546d%26entityType%3Dcollection%26workspaceId%3D00399af6-b92f-47d8-938f-0cacf755c972)
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/24309294-83bab89c-a68a-4fb1-83b7-0e3c20e2d96a?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D24309294-83bab89c-a68a-4fb1-83b7-0e3c20e2d96a%26entityType%3Dcollection%26workspaceId%3D00399af6-b92f-47d8-938f-0cacf755c972)
 
-### Step 2: Get Your PAT Token
 
-Obtain your **PAT** by *Logging into Portal → Profile Icon → Security Settings → Create Personal Access Token → Set the scopes → Confirm.*
+Alternatively, download the collection JSON and import it via **File → Import** in Postman.
 
-- Visit [this link](https://clarifai.com/signup) to create Clarifai account.
+### Step 2: Get Your PAT
 
-- Learn how to get your PAT [here](https://docs.clarifai.com/clarifai-basics/authentication/personal-access-tokens).
+A Personal Access Token (PAT) is required to authenticate all API requests.
 
-### Step 3: Set up Authorization
+See the [Personal Access Tokens documentation](https://docs.clarifai.com/control/authentication/pat) to learn how to get your PAT.
 
-Postman allows users to setup authorization in a parental level for each collection so that you dont have to add it to the headers of each request individually. To set this feature go to  **Authorization** tab of the collection and set the values as shown below.
+### Step 3: Set Your Collection Variables
 
-![Alt text](/img/postman/image-1.png)
+The collection uses **collection-level variables** — authentication and common IDs are defined once and applied automatically to every request.
 
-### Step 4: Create Your Postman Environment
+To set your variables:
 
-Set up environment in your personal workspace.
+1. Click the collection name in the Postman sidebar
+2. Go to the **Variables** tab
+3. Fill in the **Current Value** column for each variable
 
-Click on the eye icon placed on the right panel to view the environment. Click the **Add** button to create a new environment.
+The key variables to set before making any requests:
 
-![Alt text](/img/postman/image-3.png)
+| Variable | Description |
+| --- | --- |
+| `key` | Your Personal Access Token |
+| `user_id` | Your Clarifai username |
+| `app_id` | The ID of the app you want to work with |
+| `base_url` | API base URL — pre-set to `https://api.clarifai.com` |
 
-### Step 5: Add Variables to Postman Environment
+Additional variables (`model_id`, `workflow_id`, `input_id`, `dataset_id`, etc.) are used by their respective endpoint groups. Set them as you work through each section.
 
-Add the following variables to the new environment to start making API calls.
+![Postman Variables tab showing key, user_id, and app_id fields](/img/postman/image-5.png)
 
-![Alt text](/img/postman/image-5.png)
+### Step 4: Verify Authentication
 
-The values for variable can be set as following:
-- `base_url`—https://api.clarifai.com
-- `key`—Add the PAT (this is what is used for authorization)
-- `user_id`—Add the User ID 
+The collection is pre-configured with **collection-level auth** using the `Authorization: Key {{key}}` header. This means your PAT is applied automatically to every request — you don't need to set authentication per-request.
 
-### Step 6: Test Clarifai API for SUCCESS!
+To verify: click the collection name → **Authorization** tab. You should see the auth type set to `API Key` with the header value `Key {{key}}`.
 
-To test if its working , select **Applications** collection. From that select **Create Application (Universal)** request and hit **Send**. You will get the following response body if all the steps have been done correctly.
+![Postman Authorization tab showing Key auth configured at collection level](/img/postman/image-1.png)
 
-![Alt text](/img/postman/image-2.png)
+### Step 5: Make Your First Request
+
+To confirm everything is working:
+
+1. Open the **Applications** folder in the collection
+2. Select **List Applications**
+3. Click **Send**
+
+A successful response returns HTTP `200` with a JSON body containing your applications:
+
+```json
+{
+  "status": {
+    "code": 10000,
+    "description": "Ok"
+  },
+  "apps": [...]
+}
+```
+
+![Postman showing a 200 OK response from the List Applications endpoint](/img/postman/image-2.png)
+
+## Using Environments (Optional)
+
+Instead of editing collection variables directly, you can use a **Postman Environment** to manage values separately. This is useful if you work with multiple Clarifai accounts or apps.
+
+To create an environment:
+
+1. Click **Environments** in the left sidebar → **+** (New Environment)
+2. Add the same variable names (`key`, `user_id`, `app_id`, etc.) with your values
+3. Select the environment from the dropdown in the top-right corner of Postman
+
+Environment values take precedence over collection variable values when an environment is active.
+
+## Generating Code Snippets
+
+Postman can generate equivalent code in Python, Node.js, cURL, Java, and other languages for any request in the collection.
+
+To generate a snippet:
+
+1. Open any request
+2. Click the **`</>`** (Code) icon on the right panel
+3. Select your preferred language
+
+You can use the generated snippet to make the same request programmatically via the Clarifai REST API.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -125,7 +125,7 @@ const config = {
               }, 
               {
                 label: "Postman API Reference",
-                href: "https://documenter.getpostman.com/view/30622694/2s9YkuZdro"
+                href: "https://documenter.getpostman.com/view/24309294/2sBXijHWuM"
               },
               {
                 label: "Swagger API Reference",


### PR DESCRIPTION
## Summary

- Rewrote the Postman API reference page with clearer, step-by-step setup instructions
- Added a table listing all collection folders and their descriptions
- Updated collection fork URL and Postman documenter link to point to the latest workspace
- Updated the Postman API Reference nav link in `docusaurus.config.js`

## Test plan

- [ ] Verify the "Run in Postman" button forks the correct collection
- [ ] Confirm the Postman API Reference link in the navbar points to the updated documenter URL
- [ ] Check that all internal links (e.g., PAT docs) resolve correctly
- [ ] Review the page visually on the local dev server (`yarn start`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)