### PR TITLE
Update artifacts docs: no default expiration, CLI visibility column

### DIFF
--- a/code_snippets/new-docs/artifacts/output-3.txt
+++ b/code_snippets/new-docs/artifacts/output-3.txt
@@ -1,3 +1,6 @@
-clarifai artifact list users/alfrick/apps/art-app
-ARTIFACT     LATEST_VERSION                    VISIBILITY  CREATED_AT
-my-artifact  8bf6bf7ad21a452cb5a7b4f141a46b2a  PRIVATE     2026-02-03 15:02:31.319386
+VERSION                           VISIBILITY    EXPIRES_AT           CREATED_AT
+5b359e81aa8f459f866685498a7941cb  PRIVATE       Never                2026-02-11 11:24:06.409811
+8e56238288a24241909a9c92181f4352  PRIVATE       2026-12-31 23:59:59  2026-02-11 11:01:39.273495
+v123                              PRIVATE       Never                2026-02-11 10:51:55.143290
+59e5695cb44d4c47b88d5bb39246e48d  PUBLIC        Never                2026-02-11 10:30:43.724489
+6ec7d79e94434789824c882730df0ad2  PRIVATE       Never                2026-02-11 10:08:25.011732

--- a/code_snippets/new-docs/artifacts/output-3.txt
+++ b/code_snippets/new-docs/artifacts/output-3.txt
@@ -1,3 +1,3 @@
 clarifai artifact list users/alfrick/apps/art-app
-ARTIFACT     LATEST_VERSION                    CREATED_AT
-my-artifact  8bf6bf7ad21a452cb5a7b4f141a46b2a  2026-02-03 15:02:31.319386
+ARTIFACT     LATEST_VERSION                    VISIBILITY  CREATED_AT
+my-artifact  8bf6bf7ad21a452cb5a7b4f141a46b2a  PRIVATE     2026-02-03 15:02:31.319386

--- a/docs/create/artifacts/manage.md
+++ b/docs/create/artifacts/manage.md
@@ -175,7 +175,7 @@ You can upload directly to a specific artifact version by providing a version ID
 
 You can specify an expiration time using [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format (e.g., `2026-12-31T23:59:59.999Z`)
 
-> **Note:** If no `expires-at` value is specified, the artifact version will automatically expire after 7 days by default.
+> **Note:** Artifacts do not expire by default. An artifact version is only deleted if an `expires_at` value is explicitly set at upload time.
 
 <Tabs groupId="code">
 <TabItem value="python" label="Python SDK">


### PR DESCRIPTION
## Summary

- Artifacts no longer expire automatically by default; an artifact version is only deleted if `expires_at` is explicitly set at upload time
- Updated the expiration note in the Upload Artifacts section of `manage.md` to reflect this behavior
- Updated the CLI list example output (`output-3.txt`) to include the new `VISIBILITY` column alongside `LATEST_VERSION`

## Test plan

- [ ] Review the updated note under "Upload Artifacts → expiration" in the artifacts management page
- [ ] Verify the CLI list example output renders correctly with the new `VISIBILITY` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)