### PR TITLE
Add Request Routing documentation

### DIFF
--- a/code_snippets/python-sdk/compute-orchestration/cli_deploy_advanced.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_deploy_advanced.sh
@@ -1,0 +1,2 @@
+# Deploy into an existing compute cluster and nodepool (skip auto-creation)
+clarifai model deploy ./my-model --compute-cluster-id my-cluster --nodepool-id my-nodepool

--- a/code_snippets/python-sdk/compute-orchestration/cli_deploy_autoscale.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_deploy_autoscale.sh
@@ -1,0 +1,2 @@
+# Deploy with custom autoscaling (2 replicas minimum, up to 10)
+clarifai model deploy ./my-model --instance g5.xlarge --min-replicas 2 --max-replicas 10

--- a/code_snippets/python-sdk/compute-orchestration/cli_deploy_cloud.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_deploy_cloud.sh
@@ -1,0 +1,2 @@
+# Deploy to a specific cloud provider and region
+clarifai model deploy ./my-model --instance g5.xlarge --cloud aws --region us-east-1

--- a/code_snippets/python-sdk/compute-orchestration/cli_deploy_verbose.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_deploy_verbose.sh
@@ -1,0 +1,2 @@
+# Deploy with detailed build, upload, and monitoring logs
+clarifai model deploy ./my-model --instance g5.xlarge --verbose

--- a/code_snippets/python-sdk/compute-orchestration/cli_deploy_version.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_deploy_version.sh
@@ -1,0 +1,2 @@
+# Deploy a specific model version by URL
+clarifai model deploy --model-url https://clarifai.com/user/app/models/my-model --model-version-id abc12345 --instance g5.xlarge

--- a/code_snippets/python-sdk/compute-orchestration/cli_list_instances.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_list_instances.sh
@@ -1,0 +1,17 @@
+# List all available compute instances
+clarifai list-instances
+
+# Filter by cloud provider
+clarifai list-instances --cloud aws
+
+# Filter by GPU type
+clarifai list-instances --gpu L40S
+
+# Filter by minimum GPU count
+clarifai list-instances --min-gpus 2
+
+# Filter by minimum GPU memory
+clarifai list-instances --min-gpu-mem 48Gi
+
+# Combine multiple filters
+clarifai list-instances --cloud aws --gpu L40S --region us-east-1

--- a/code_snippets/python-sdk/compute-orchestration/cli_model_logs.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_model_logs.sh
@@ -1,0 +1,14 @@
+# Stream model stdout/stderr logs (follows by default)
+clarifai model logs --deployment deploy-abc123
+
+# View Kubernetes scheduling and scaling events
+clarifai model logs --deployment deploy-abc123 --log-type events
+
+# Print current logs and exit (no follow)
+clarifai model logs --deployment deploy-abc123 --no-follow
+
+# Stream logs for 60 seconds then stop
+clarifai model logs --deployment deploy-abc123 --duration 60
+
+# Logs by model URL instead of deployment ID
+clarifai model logs --model-url https://clarifai.com/user/app/models/my-model

--- a/code_snippets/python-sdk/compute-orchestration/cli_model_status.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_model_status.sh
@@ -1,0 +1,8 @@
+# Check status by deployment ID
+clarifai model status --deployment deploy-abc123
+
+# Check all deployments for a model
+clarifai model status user_id/app_id/models/model_id
+
+# Check status by model URL
+clarifai model status --model-url https://clarifai.com/user/app/models/my-model

--- a/code_snippets/python-sdk/compute-orchestration/cli_model_undeploy.sh
+++ b/code_snippets/python-sdk/compute-orchestration/cli_model_undeploy.sh
@@ -1,0 +1,8 @@
+# Remove deployment by ID
+clarifai model undeploy --deployment deploy-abc123
+
+# Remove deployment by model reference
+clarifai model undeploy user_id/app_id/models/model_id
+
+# Remove deployment by model URL
+clarifai model undeploy --model-url https://clarifai.com/user/app/models/my-model

--- a/docs/compute/deployments/deploy-model.md
+++ b/docs/compute/deployments/deploy-model.md
@@ -34,6 +34,18 @@ import OutputCURLRestrictDeployment from "!!raw-loader!../../../code_snippets/py
 
 import Curl1 from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/curl_deployment.sh";
 
+import CLIDeployModel from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_deploy_model.sh";
+import CLIDeployUrl from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_deploy_url.sh";
+import CLIDeployCloud from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_deploy_cloud.sh";
+import CLIDeployAutoscale from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_deploy_autoscale.sh";
+import CLIDeployAdvanced from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_deploy_advanced.sh";
+import CLIDeployVerbose from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_deploy_verbose.sh";
+import CLIDeployVersion from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_deploy_version.sh";
+import CLIModelStatus from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_model_status.sh";
+import CLIModelLogs from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_model_logs.sh";
+import CLIModelUndeploy from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_model_undeploy.sh";
+import CLIListInstances from "!!raw-loader!../../../code_snippets/python-sdk/compute-orchestration/cli_list_instances.sh";
+
 
 
 ## **Via the UI**
@@ -185,7 +197,16 @@ Once the deployment is created, you’ll be redirected to the nodepool page, whe
 
 ## **Via the CLI**
 
-The Clarifai CLI provides a one-command deployment workflow that handles all infrastructure creation automatically. No need to manually create clusters or nodepools first.
+The Clarifai CLI provides a one-command deployment workflow — `clarifai model deploy` — that handles uploading, infrastructure creation, and deployment automatically. No need to manually create clusters or nodepools first.
+
+:::info Prerequisites
+
+Before deploying, make sure you have:
+- The `clarifai` Python package installed (`pip install --upgrade clarifai`)
+- Logged in via `clarifai login` (or have `CLARIFAI_PAT` set)
+- A model directory with `config.yaml`, `1/model.py`, and `requirements.txt` — or a model already uploaded to Clarifai
+
+:::
 
 ### One-Command Deploy
 
@@ -193,100 +214,204 @@ Deploy a local model directory to the cloud in a single step:
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
-
-```bash
-clarifai model deploy ./my-model --instance g5.xlarge
-```
-
+    <CodeBlock className="language-bash">{CLIDeployModel}</CodeBlock>
 </TabItem>
 </Tabs>
 
-This uploads your model, creates a compute cluster and nodepool, deploys the model, and monitors until it's ready.
+This single command orchestrates the full deployment pipeline:
+
+1. **Validate** — checks `config.yaml`, verifies checkpoint sources (e.g., HuggingFace repo accessibility), and resolves the instance type
+2. **Upload** — builds a Docker image from your model directory and pushes it to Clarifai
+3. **Deploy** — auto-creates a compute cluster and nodepool (if they don't already exist), then creates a deployment
+4. **Monitor** — streams pod events in real-time until the model is ready for inference
+
+When it finishes, you'll see output like:
+
+```text
+── Ready ──────────────────────────────────────────────
+  Model deployed successfully!
+
+  Model:           https://clarifai.com/your-user/main/models/my-model
+  Version:         abc12345
+  Deployment:      deploy-my-model-dd8481
+  Instance:        g5.xlarge
+  Cloud:           AWS / us-east-1
+
+══════════════════════════════════════════════════════
+# Here is a code snippet to use this model:
+══════════════════════════════════════════════════════
+  ...Python SDK predict code...
+══════════════════════════════════════════════════════
+
+── Next Steps ─────────────────────────────────────────
+  Predict:         clarifai model predict your-user/main/models/my-model "Hello"
+  Playground:      https://clarifai.com/playground?model=my-model__abc12345&...
+  Logs:            clarifai model logs --deployment "deploy-my-model-dd8481"
+  Status:          clarifai model status --deployment "deploy-my-model-dd8481"
+  Undeploy:        clarifai model undeploy --deployment "deploy-my-model-dd8481"
+```
+
+> **Tip:** Copy the predict command directly from the output — it contains your actual user ID and deployment ID.
 
 ### Deploy an Already-Uploaded Model
 
-If your model is already uploaded to Clarifai, deploy it by URL:
+If your model is already uploaded to Clarifai, deploy it by URL (skips the upload phase):
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIDeployUrl}</CodeBlock>
+</TabItem>
+</Tabs>
 
-```bash
-clarifai model deploy --model-url https://clarifai.com/user/app/models/my-model --instance g5.xlarge
-```
+To deploy a specific version rather than the latest:
 
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIDeployVersion}</CodeBlock>
 </TabItem>
 </Tabs>
 
 ### Browse Available Instances
 
-View all available hardware configurations using the dedicated `list-instances` command:
+Before deploying, you can view all available hardware configurations using the `list-instances` command:
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIListInstances}</CodeBlock>
+</TabItem>
+</Tabs>
 
-```bash
-# List all available instances
-clarifai list-instances
+> **Alias:** `clarifai li` is a shorthand for `clarifai list-instances`.
 
-# Filter by cloud provider
-clarifai list-instances --cloud aws
+The output shows instance type IDs, GPU names, GPU memory, CPU cores, cloud provider, and region — helping you choose the right hardware for your model.
 
-# Filter by GPU type
-clarifai list-instances --gpu L40S
+### Multi-Cloud Deployment
 
-# Or use the deploy flag shortcut
-clarifai model deploy --instance-info
-clarifai model deploy --instance-info --cloud aws
-```
+Clarifai supports deployment across AWS, GCP, and Vultr. By default, the cloud provider and region are **auto-detected** from the `--instance` type. You can override this explicitly:
 
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIDeployCloud}</CodeBlock>
 </TabItem>
 </Tabs>
 
 ### Override Instance Type
 
-If your `config.yaml` already has a `compute.instance` value (auto-selected during `model init`), you can override it at deploy time. The `--instance` flag **always takes priority** over the config:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
+If your `config.yaml` already has a `compute.instance` value (auto-selected during `clarifai model init`), you can override it at deploy time. The `--instance` flag **always takes priority** over the config:
 
 ```bash
-# config.yaml has compute.instance: g5.xlarge, but deploy with a larger GPU
-clarifai model deploy ./my-model --instance g6e.2xlarge
+# config.yaml has compute.instance: g4dn.xlarge, but deploy with a larger GPU
+clarifai model deploy ./my-model --instance g5.xlarge
 ```
-
-</TabItem>
-</Tabs>
 
 ### Autoscaling
 
-Control how your deployment scales:
+Control how your deployment scales with minimum and maximum replica counts:
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
-
-```bash
-clarifai model deploy ./my-model --instance g5.xlarge --min-replicas 2 --max-replicas 10
-```
-
+    <CodeBlock className="language-bash">{CLIDeployAutoscale}</CodeBlock>
 </TabItem>
 </Tabs>
 
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--min-replicas` | `1` | Minimum number of running replicas. Set higher for production workloads to avoid cold starts. |
+| `--max-replicas` | `5` | Maximum replicas for autoscaling. The platform scales up automatically based on traffic. |
+
+> For advanced autoscaling settings (scale-to-zero, delay timers, traffic history), use the [UI deployment flow](#via-the-ui) or the [API](#via-the-api).
+
+### Verbose Mode
+
+For debugging or visibility into the full deployment pipeline, use the `--verbose` flag:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIDeployVerbose}</CodeBlock>
+</TabItem>
+</Tabs>
+
+This shows detailed Docker build logs, upload progress, and all Kubernetes pod events (including transient scheduling events that are hidden by default).
+
+### Advanced: Use Existing Infrastructure
+
+If you've already created a compute cluster and nodepool (via the UI or API), you can deploy directly into them without auto-creation:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIDeployAdvanced}</CodeBlock>
+</TabItem>
+</Tabs>
+
+### CLI Reference
+
+Here is the full list of flags for `clarifai model deploy`:
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `MODEL_PATH` | argument | `.` (current dir) | Local model directory to upload and deploy. Not needed when using `--model-url`. |
+| `--instance` | string | from config | Hardware instance type (e.g., `g5.xlarge`). Use `clarifai list-instances` to see options. |
+| `--model-url` | string | — | Clarifai model URL to deploy (skips upload). |
+| `--model-version-id` | string | latest | Specific model version to deploy. |
+| `--min-replicas` | int | `1` | Minimum number of running replicas. |
+| `--max-replicas` | int | `5` | Maximum replicas for autoscaling. |
+| `--cloud` | string | auto | Cloud provider (`aws`, `gcp`, `vultr`). Auto-detected from instance if omitted. |
+| `--region` | string | auto | Cloud region (e.g., `us-east-1`). Auto-detected from instance if omitted. |
+| `--compute-cluster-id` | string | — | [Advanced] Existing compute cluster ID (skips auto-creation). |
+| `--nodepool-id` | string | — | [Advanced] Existing nodepool ID (skips auto-creation). |
+| `--verbose` / `-v` | flag | off | Show detailed build, upload, and deployment logs. |
+
+---
+
 ### Lifecycle Management
 
-After deployment, use these commands to manage it:
+After deployment, the CLI provides commands to monitor, debug, and manage your deployed models.
 
-```bash
-# Check status
-clarifai model status --deployment <deployment-id>
+#### Check Deployment Status
 
-# Stream logs
-clarifai model logs --deployment <deployment-id>
+View the current state of a deployment — including enabled/disabled status, live and desired replica counts, instance type, GPU info, and timing:
 
-# Remove deployment
-clarifai model undeploy --deployment <deployment-id>
-```
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIModelStatus}</CodeBlock>
+</TabItem>
+</Tabs>
 
-For the full options reference, see the [CLI Reference](https://docs.clarifai.com/resources/api-overview/cli#clarifai-model-deploy).
+#### Stream Logs
+
+Stream stdout/stderr from the runner pod — useful for monitoring model loading, inference, and debugging errors:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIModelLogs}</CodeBlock>
+</TabItem>
+</Tabs>
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--log-type` | `model` | Log type: `model` (stdout/stderr) or `events` (Kubernetes scheduling/scaling events). |
+| `--follow` / `--no-follow` | `--follow` | Continuously tail new logs. Use `--no-follow` to print and exit. |
+| `--duration` | unlimited | Stop after N seconds. Press Ctrl+C to stop if not set. |
+
+> **Tip:** Use `--log-type events` when your pod is stuck starting — it shows Kubernetes scheduling, image pulling, and scaling events that explain why a pod hasn't started yet.
+
+#### Remove a Deployment
+
+Permanently stop serving the model and delete the deployment. The model version and compute infrastructure remain intact — you can re-deploy at any time:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{CLIModelUndeploy}</CodeBlock>
+</TabItem>
+</Tabs>
+
+:::warning
+
+Removing a deployment stops all inference on that model immediately. Any in-flight requests will fail. Make sure to redirect traffic before undeploying production models.
+
+:::
+
+For the full CLI reference, see the [CLI documentation](https://docs.clarifai.com/resources/api-overview/cli#clarifai-model-deploy).
 
 ## **Via the API**
 

--- a/docs/compute/inference/routing.md
+++ b/docs/compute/inference/routing.md
@@ -1,0 +1,99 @@
+---
+description: How Clarifai routes prediction requests across nodepools and replicas
+sidebar_position: 8
+---
+
+# Request Routing
+
+**How Clarifai routes prediction requests for optimal performance**
+<hr />
+
+When you send a prediction request to a deployed model, Clarifai's routing system determines where that request is processed. Routing happens at two levels: first selecting the right **nodepool** (which hardware), then selecting the right **replica** (which pod within that hardware).
+
+This page covers both levels, what Clarifai optimizes automatically, and what you can configure.
+
+## Nodepool Selection
+
+When a request arrives, Clarifai picks a nodepool in this order:
+
+1. **Explicit routing** — If you specify a `deployment_id` (or `compute_cluster_id` + `nodepool_id`) in the request, the request goes directly to that nodepool.
+2. **Deployment lookup** — If you don't specify routing, Clarifai finds active deployments for the model version and picks the best nodepool based on queue depth and latency.
+3. **Shared compute fallback** — For Clarifai-owned models with no user deployment, the request falls back to Clarifai's shared infrastructure.
+
+### Multi-Nodepool Deployments
+
+A single deployment can span **multiple nodepools** with priority ordering. When you add nodepools to a deployment, you assign each a priority rank (1 being highest). Requests are routed to the highest-priority nodepool that has available capacity, with overflow spilling to the next.
+
+This enables several powerful patterns:
+
+- **Cross-cloud failover** — Place nodepools in different cloud providers (AWS, GCP) so traffic fails over automatically if one region has issues.
+- **Cross-hardware routing** — Since Clarifai's Compute Orchestration supports any hardware, you can route between **NVIDIA and AMD GPUs**, or even between **GPU and CPU** nodepools, within a single deployment. This means you can mix x86 and ARM architectures, or combine spot and on-demand instances for cost optimization.
+- **Tiered performance** — Use a high-performance GPU nodepool as primary and a cheaper instance as overflow.
+
+Configure multi-nodepool deployments in the UI by dragging nodepools into your preferred priority order, or via the API using `deployment_nodepools` with `sequence` values.
+
+### Request-Level Routing
+
+You can override the default routing on a per-request basis using the `runner_selector` field on `PostModelOutputsRequest`:
+
+```python
+# Route to a specific deployment
+response = model.predict(inputs, deployment_id="my-deployment")
+
+# Route to a specific nodepool
+response = model.predict(inputs, compute_cluster_id="my-cluster", nodepool_id="my-nodepool")
+```
+
+## Automatic Replica Optimization
+
+Once a nodepool is selected, Clarifai intelligently routes the request to the replica most likely to deliver the fastest response. This is fully automatic — you don't configure it, but understanding what it does helps you design better deployments.
+
+### KV Cache Affinity
+
+For models backed by inference engines with KV caching (such as vLLM and SGLang), Clarifai routes requests to replicas that already have relevant **KV cache state** loaded in memory. This avoids redundant recomputation of attention keys and values, resulting in higher throughput and lower time-to-first-token (TTFT).
+
+This is especially effective for:
+
+- **Shared system prompts** — Multiple users hitting the same model with the same system instruction benefit from cache reuse across all requests, not just their own.
+- **RAG pipelines** — Users querying the same knowledge base share cached context automatically.
+- **Multi-turn conversations** — Follow-up messages reuse cached state from earlier turns.
+
+### Session Awareness
+
+Clarifai tracks which replicas have recently served each user and favors routing subsequent requests from the same user to the same replica. This further improves cache reuse for conversational workloads without any client-side session management.
+
+## Autoscaling
+
+Autoscaling controls how many replicas are running within a nodepool. You configure this per-nodepool within a deployment:
+
+| Setting | Default | Description |
+|---|---|---|
+| **Min Replicas** | `0` | Minimum instances always running. Set `≥ 1` to avoid cold starts |
+| **Max Replicas** | `5` | Ceiling for autoscaling |
+| **Scale Up Delay** | `300s` | Wait before adding replicas after traffic increases |
+| **Scale Down Delay** | `300s` | Wait before removing replicas after traffic drops |
+| **Scale to Zero Delay** | `1800s` | Idle time before scaling to zero (only when min replicas = 0) |
+| **Traffic History** | `300s` | How far back to look at traffic data for scaling decisions |
+| **Disable Packing** | `false` | When `true`, restricts to one replica per node for isolation |
+
+Configure autoscaling in the UI during deployment, or via the CLI:
+
+```bash
+clarifai model deploy ./my-model --min-replicas 1 --max-replicas 10
+```
+
+> For advanced autoscaling settings (scale-to-zero delays, traffic history, packing), use the [UI deployment flow](https://docs.clarifai.com/compute/deployments/deploy-model#step-4-set-autoscaling) or the API.
+
+More replicas means more capacity and better cache distribution across your deployment.
+
+## Prediction Caching
+
+For identical requests, you can skip inference entirely by enabling the prediction cache:
+
+```python
+response = model.predict(inputs, use_predict_cache=True)
+```
+
+When enabled, Clarifai caches the full response for identical input+model+version combinations. Subsequent identical requests return the cached result instantly without hitting compute.
+
+This is separate from KV cache routing — prediction caching avoids compute entirely, while KV cache routing optimizes the compute that does happen.

--- a/docs/compute/toolkits/sglang.md
+++ b/docs/compute/toolkits/sglang.md
@@ -133,6 +133,8 @@ To see all available instance types and pricing:
 
 > **Tip:** If you have a local Linux GPU and want to test before deploying, run `clarifai model serve ./Qwen3-4B --mode env` first.
 
+> **Note:** Clarifai automatically optimizes replica routing using KV cache affinity, improving throughput for shared system prompts, RAG pipelines, and multi-turn conversations. See [Request Routing](https://docs.clarifai.com/compute/inference/routing) for details.
+
 ## Step 5: Run Inference
 
 <Tabs groupId="code">

--- a/docs/compute/toolkits/vllm.md
+++ b/docs/compute/toolkits/vllm.md
@@ -132,6 +132,8 @@ To see all available instance types and pricing:
 
 > **Tip:** If you have a local GPU and want to test before deploying, run `clarifai model serve ./Qwen3-0.6B --mode env` first.
 
+> **Note:** Clarifai automatically optimizes replica routing using KV cache affinity, improving throughput for shared system prompts, RAG pipelines, and multi-turn conversations. See [Request Routing](https://docs.clarifai.com/compute/inference/routing) for details.
+
 ## Step 5: Run Inference
 
 <Tabs groupId="code">


### PR DESCRIPTION
## Summary
- New page `docs/compute/inference/routing.md` documenting how Clarifai routes prediction requests
- Covers nodepool selection, multi-nodepool deployments with cross-cloud/cross-hardware routing, KV cache affinity, session awareness, autoscaling config, and prediction caching
- Added cross-references from vLLM and SGLang toolkit pages

## Notes
- Competitive-sensitive implementation details (algorithms, data structures, dispatch phases) intentionally omitted
- Benchmark numbers omitted pending TTFT benchmarking
- Warm pools/pods documentation deferred to a future PR
- Scheduling strategies (Performance, Network, Utilization, etc.) not documented since backend TODO shows they aren't implemented yet

## Test plan
- [ ] Review routing.md for accuracy with eng team
- [ ] Verify cross-references render correctly on vLLM and SGLang pages
- [ ] Confirm autoscaling defaults match current production values

🤖 Generated with [Claude Code](https://claude.com/claude-code)