### PR TITLE
Improve KV cache routing documentation

### DIFF
--- a/docs/compute/inference/routing.md
+++ b/docs/compute/inference/routing.md
@@ -48,25 +48,25 @@ response = model.predict(inputs, compute_cluster_id="my-cluster", nodepool_id="m
 
 Once a nodepool is selected, Clarifai intelligently routes the request to the replica most likely to deliver the fastest response. This is fully automatic — you don't configure it, but understanding what it does helps you design better deployments.
 
-### KV Cache Affinity
+### KV Cache Routing (Prefix Cache Routing)
 
-For models backed by inference engines with KV caching (such as vLLM and SGLang), Clarifai routes requests to replicas that already have relevant **KV cache state** loaded in memory. This avoids redundant recomputation of attention keys and values, resulting in higher throughput and lower time-to-first-token (TTFT).
+For models backed by inference engines with KV caching (such as vLLM and SGLang), Clarifai detects shared prompt prefixes and routes requests to replicas that already hold those prefixes in their KV cache. This avoids redundant recomputation of attention keys and values, resulting in higher throughput and lower time-to-first-token (TTFT).
 
 This is fully automatic — no configuration or code changes required.
 
 This is especially effective for:
 
-- **Shared system prompts** — Multiple users hitting the same model with the same system instruction benefit from cache reuse across all requests, not just their own.
-- **RAG pipelines** — Users querying the same knowledge base share cached context automatically.
-- **Multi-turn conversations** — Follow-up messages reuse cached state from earlier turns.
+- **Shared system prompts** — Multiple users hitting the same model with the same system instruction share the same prefix. Rather than recomputing it on every replica, requests are routed to replicas that already have that prefix cached.
+- **RAG pipelines** — Users querying the same knowledge base receive similar retrieved-document prefixes, which are automatically reused across requests.
+- **Multi-turn conversations** — Follow-up messages share the prior conversation as a prefix, so subsequent turns reuse cached state from earlier turns.
 
-When a cache-aware match is found, the request routes to the best-matched replica. When no match exists, the system falls back gracefully — there is no performance penalty compared to routing without this feature.
+When a matching prefix is found, the request routes to the best-matched replica. When no prefix match exists, the system falls back gracefully — there is no performance penalty compared to routing without this feature.
 
 ### Session Awareness
 
 Clarifai tracks which replicas have recently served each user and favors routing subsequent requests from the same user to the same replica. This improves cache reuse for conversational workloads without any client-side session management.
 
-KV cache affinity and session awareness work together in a priority chain: **KV cache match → session affinity → random selection**. KV cache affinity handles prefix sharing *across* users (e.g., shared system prompts), while session awareness handles reuse *within* a single user's conversation. If neither signal applies, the system falls back to random selection with no degradation.
+KV cache routing (prefix cache routing) and session awareness work together in a priority chain: **prefix cache match → session affinity → random selection**. Prefix cache routing handles shared prefixes *across* users (e.g., shared system prompts), while session awareness handles reuse *within* a single user's conversation. If neither signal applies, the system falls back to random selection with no degradation.
 
 ## Autoscaling
 
@@ -100,7 +100,7 @@ More replicas means more capacity and better cache distribution across your depl
 
 :::note Cache and Scaling
 
-When new replicas scale up, they start with an empty KV cache — cache affinity effectiveness improves as replicas warm up over time. When replicas scale down, cached state on those replicas is lost. For latency-sensitive workloads, setting `min_replicas ≥ 1` ensures you always have warm replicas with populated caches.
+When new replicas scale up, they start with an empty KV cache — prefix cache routing effectiveness improves as replicas warm up over time. When replicas scale down, cached state on those replicas is lost. For latency-sensitive workloads, setting `min_replicas ≥ 1` ensures you always have warm replicas with populated caches.
 
 :::
 
@@ -114,8 +114,8 @@ response = model.predict(inputs, use_predict_cache=True)
 
 When enabled, Clarifai caches the full response for identical input+model+version combinations. Subsequent identical requests return the cached result instantly without hitting compute.
 
-This is separate from KV cache routing — prediction caching avoids compute entirely, while KV cache routing optimizes the compute that does happen.
+This is separate from KV cache routing (prefix cache routing) — prediction caching avoids compute entirely, while prefix cache routing optimizes the compute that does happen.
 
 ## Inference Cost and Cache Hits
 
-When KV cache affinity routes a request to a replica with cached state, the cached portion of the prompt can be billed at a reduced rate. This depends on the model reporting `cached_tokens` in the response usage metadata — most vLLM and SGLang-backed models support this, but coverage may vary. If you're unsure whether a specific model reports cached tokens, [contact us](https://www.clarifai.com/company/contact).
+When KV cache routing (prefix cache routing) routes a request to a replica with cached prefix state, the cached portion of the prompt can be billed at a reduced rate. This depends on the model reporting `cached_tokens` in the response usage metadata — most vLLM and SGLang-backed models support this, but coverage may vary. If you're unsure whether a specific model reports cached tokens, [contact us](https://www.clarifai.com/company/contact).

--- a/docs/compute/inference/routing.md
+++ b/docs/compute/inference/routing.md
@@ -52,15 +52,21 @@ Once a nodepool is selected, Clarifai intelligently routes the request to the re
 
 For models backed by inference engines with KV caching (such as vLLM and SGLang), Clarifai routes requests to replicas that already have relevant **KV cache state** loaded in memory. This avoids redundant recomputation of attention keys and values, resulting in higher throughput and lower time-to-first-token (TTFT).
 
+This is fully automatic — no configuration or code changes required.
+
 This is especially effective for:
 
 - **Shared system prompts** — Multiple users hitting the same model with the same system instruction benefit from cache reuse across all requests, not just their own.
 - **RAG pipelines** — Users querying the same knowledge base share cached context automatically.
 - **Multi-turn conversations** — Follow-up messages reuse cached state from earlier turns.
 
+When a cache-aware match is found, the request routes to the best-matched replica. When no match exists, the system falls back gracefully — there is no performance penalty compared to routing without this feature.
+
 ### Session Awareness
 
-Clarifai tracks which replicas have recently served each user and favors routing subsequent requests from the same user to the same replica. This further improves cache reuse for conversational workloads without any client-side session management.
+Clarifai tracks which replicas have recently served each user and favors routing subsequent requests from the same user to the same replica. This improves cache reuse for conversational workloads without any client-side session management.
+
+KV cache affinity and session awareness work together in a priority chain: **KV cache match → session affinity → random selection**. KV cache affinity handles prefix sharing *across* users (e.g., shared system prompts), while session awareness handles reuse *within* a single user's conversation. If neither signal applies, the system falls back to random selection with no degradation.
 
 ## Autoscaling
 
@@ -92,6 +98,12 @@ Clarifai pre-warms popular instance types automatically so new replicas are read
 
 More replicas means more capacity and better cache distribution across your deployment.
 
+:::note Cache and Scaling
+
+When new replicas scale up, they start with an empty KV cache — cache affinity effectiveness improves as replicas warm up over time. When replicas scale down, cached state on those replicas is lost. For latency-sensitive workloads, setting `min_replicas ≥ 1` ensures you always have warm replicas with populated caches.
+
+:::
+
 ## Prediction Caching
 
 For identical requests, you can skip inference entirely by enabling the prediction cache:
@@ -103,3 +115,7 @@ response = model.predict(inputs, use_predict_cache=True)
 When enabled, Clarifai caches the full response for identical input+model+version combinations. Subsequent identical requests return the cached result instantly without hitting compute.
 
 This is separate from KV cache routing — prediction caching avoids compute entirely, while KV cache routing optimizes the compute that does happen.
+
+## Inference Cost and Cache Hits
+
+When KV cache affinity routes a request to a replica with cached state, the cached portion of the prompt can be billed at a reduced rate. This depends on the model reporting `cached_tokens` in the response usage metadata — most vLLM and SGLang-backed models support this, but coverage may vary. If you're unsure whether a specific model reports cached tokens, [contact us](https://www.clarifai.com/company/contact).


### PR DESCRIPTION
## Summary
- Clarify that KV cache affinity is zero-config with graceful fallback (no perf penalty when no match)
- Document the routing priority chain: KV cache match → session affinity → random
- Explain how KV cache affinity (cross-user prefix sharing) and session awareness (per-user reuse) complement each other
- Add note about cache behavior during autoscaling (cold replicas, lost state on scale-down)
- Add inference cost section explaining `cached_tokens` billing (model-dependent)

## Test plan
- [ ] Verify docs build cleanly
- [ ] Review rendering of the new `:::note` admonition in the autoscaling section
- [ ] Confirm contact link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)