### PR TITLE
Wire dependent docs into the new Python-first pipelines structure (slimmer model-type guides)

### DIFF
--- a/docs/create/models/visual-classifier.md
+++ b/docs/create/models/visual-classifier.md
@@ -550,26 +550,9 @@ Then run the following command, pointing to your config file:
 
 ### Step 5: Initialize a Pipeline from a Template
 
-The [`classifier-pipeline-resnet`](https://github.com/Clarifai/pipeline-examples/tree/main/classifier-pipeline-resnet) template lets you quickly set up a visual classification pipeline using a preconfigured ResNet-based image classifier — so you can focus on training rather than setup.
+The [`classifier-pipeline-resnet`](https://github.com/Clarifai/pipeline-examples/tree/main/classifier-pipeline-resnet) template lets you quickly set up a visual classification pipeline using a preconfigured ResNet-based image classifier — so you can focus on training rather than setup. It's one of several pipeline templates for common ML workflows; see the [Pipeline Templates](https://docs.clarifai.com/compute/pipelines/templates) page for the full list and how to discover what's available.
 
-:::tip
-
-To view all the available predefined templates, run:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipelinetemplate list</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output5}</CodeBlock>
-</details>
-
-:::
- 
-Run the following command to [initialize a pipeline](https://docs.clarifai.com/compute/pipelines/create-api#step-2-initialize-a-pipeline-project) from the template:
+Run the following command to scaffold a project from the template, pointing it at the dataset and concepts you set up in the previous steps:
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
@@ -585,25 +568,22 @@ Run the following command to [initialize a pipeline](https://docs.clarifai.com/c
 </TabItem>
 </Tabs>
 
-Where:
+The classifier-specific parameters above are:
 
 | Parameter | Description |
 |---|---|
-| `--app_id` | The ID of the app where the pipeline will be created |
-| `--user_id` | Your Clarifai user ID |
-| `--template` | The pipeline template to use. Here, we use `classifier-pipeline-resnet` |
 | `--set dataset_id` | The ID of the dataset to use for training |
-| `--set dataset_version_id` | The specific dataset version to use for training|
+| `--set dataset_version_id` | The specific dataset version to use for training |
 | `--set concepts` | A JSON array of the concept labels the model will be trained to classify |
+
+For the full reference on `clarifai pipeline init` — including `--template`, `--set`, `--user_id`/`--app_id`, and overriding any other template default at init time — see the [Pipeline Templates](https://docs.clarifai.com/compute/pipelines/templates) page.
 
 <details>
   <summary>Example Output</summary>
     <CodeBlock className="language-python">{Output6}</CodeBlock>
 </details>
 
-Once executed, the command creates a new project directory named after the template, preloaded with all necessary configuration files.
-
-Before running any subsequent `clarifai pipeline ...` commands, navigate into the generated directory — these commands rely on the local `config.yaml` and `config-lock.yaml` files:
+Once executed, the command creates a project directory named after the template, preloaded with the necessary configuration files. Before running any subsequent `clarifai pipeline ...` commands, navigate into the generated directory:
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
@@ -611,26 +591,7 @@ Before running any subsequent `clarifai pipeline ...` commands, navigate into th
 </TabItem>
 </Tabs>
 
-> **Note:** You can optionally review the generated pipeline steps and tailor them to your use case. If needed, you can also adjust the default parameters and add any additional dependencies to the `requirements.txt` files to support your pipeline.
-
-:::tip Override Defaults at Initialization
-
-You can optionally customize the pipeline during setup — for example, by specifying a different user/app, assigning a custom pipeline ID, or adjusting model parameters:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-  clarifai pipeline init --template=classifier-pipeline-resnet \
-  --user_id your_custom_user_id \
-  --app_id your_custom_app_id \
-  --set id=your_custom_pipeline_id \
-  --set num_epochs=20
-```
-</TabItem>
-</Tabs>
-
-
-:::
+> **Note:** You can review the generated pipeline steps and tailor them to your use case — adjust default parameters, add dependencies to the `requirements.txt` files, or modify step logic. For an alternative, Python-first authoring path that lets you skip the scaffold-and-edit flow entirely, see the [Pipeline DSL reference](https://docs.clarifai.com/compute/pipelines/dsl-reference).
 
 ### Step 6: Upload Your Pipeline
 

--- a/docs/create/models/visual-classifier.md
+++ b/docs/create/models/visual-classifier.md
@@ -17,35 +17,10 @@ A visual classifier is a deep fine-tuned model that categorizes images and video
 
 For example, it can be used to categorize images into concepts such as "cat", "dog", or "vehicle".
 
-:::note pipeline template
-
-A pipeline template is a pre-configured workflow that defines how a model is trained, evaluated, and deployed.
-
-It is built on top of [Clarifai Pipelines](https://docs.clarifai.com/compute/pipelines/), which are the underlying system that orchestrates a sequence of steps (nodes) such as data processing, training, and evaluation. The template simply provides a ready-made, opinionated setup of these pipelines for a specific use case.
-
-Instead of building everything from scratch, a pipeline template gives you a ready-made structure with:
-
-* **Predefined steps** (e.g., data loading, preprocessing, training, evaluation)
-* **Default configurations** (such as model architecture and training logic)
-* **Tunable parameters** (hyperparameters you can adjust to fit your use case)
-
-In practical terms, it acts as a blueprint for your training process. For example, when you select the [`classifier-pipeline-resnet`](#select-training-template) template, you're choosing:
-
-* A pipeline designed for image classification
-* A ResNet-based model architecture
-* A sequence of steps already wired together using Clarifai Pipelines to train on labeled image data
-
-:::
-
 ![Image classification example](/img/others-2/image_classification_example.webp)
 <center>*Image classification example*</center>
 
-
-You may choose a visual classifier model type in cases where:
-
-- **Accuracy takes priority** — you need a carefully targeted solution rather than a fast, general-purpose one.
-- **Your data is unique** — existing Clarifai models don't recognize the features in your dataset, and you need to deep fine-tune a custom model integrated into your workflows.
-- **You have the right ingredients** — a custom dataset, accurate labels, and the time and expertise to fine-tune.
+Use a visual classifier when you have a labeled dataset and want a custom model fine-tuned on your own classes.
 
 :::tip
 
@@ -53,6 +28,78 @@ Visual classifiers are optimized for classification tasks. If you need to locate
 
 :::
 
+You can train a visual classifier two ways:
+
+- **[Via the CLI](#via-the-cli)** — Scriptable and reproducible. Recommended for engineering workflows. Train an end-to-end model in three commands.
+- **[Via the UI](#via-the-ui)** — Click-through training from the Clarifai web app. Recommended for quick experiments without writing code.
+
+##  **Via the CLI**
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from "@theme/CodeBlock";
+
+### Prerequisites
+
+Install the Clarifai CLI and authenticate:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{`pip install --upgrade clarifai
+clarifai login`}</CodeBlock>
+</TabItem>
+</Tabs>
+
+`clarifai login` auto-detects your user ID and saves your [Personal Access Token (PAT)](https://docs.clarifai.com/control/authentication/pat/) locally.
+
+### Train a Classifier (Quick Demo)
+
+The fastest way to see a working classifier end-to-end is the [`classifier-pipeline-resnet-quick-start`](https://github.com/Clarifai/pipeline-examples/tree/main/classifier-pipeline-resnet-quick-start) template. It uses a Clarifai-hosted Food-101 subset as the training dataset, with sensible defaults for every hyperparameter — so no dataset setup or `--set` flags are required.
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{`clarifai pipeline init --template classifier-pipeline-resnet-quick-start
+cd classifier-pipeline-resnet-quick-start
+clarifai pipeline upload
+clarifai pipeline run --instance=g6e.xlarge`}</CodeBlock>
+</TabItem>
+</Tabs>
+
+That's it. `--instance=g6e.xlarge` auto-provisions a compute cluster and nodepool — no separate setup required. The pipeline trains a ResNet-50 image classifier on the public dataset and registers the trained model in your Clarifai model registry.
+
+### Train on Your Own Data
+
+When you want to train a classifier on your own concepts, use the [`classifier-pipeline-resnet`](https://github.com/Clarifai/pipeline-examples/tree/main/classifier-pipeline-resnet) template with `--set` flags pointing at your uploaded dataset:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+```bash
+clarifai pipeline init --template classifier-pipeline-resnet \
+  --set dataset_id=your_dataset_id \
+  --set dataset_version_id=your_dataset_version_id \
+  --set concepts='["class1","class2","..."]'
+cd classifier-pipeline-resnet
+clarifai pipeline upload
+clarifai pipeline run --instance=g6e.xlarge
+```
+</TabItem>
+</Tabs>
+
+Where:
+
+| Parameter | Description |
+|---|---|
+| `--set dataset_id` | The ID of the dataset to train on |
+| `--set dataset_version_id` | The specific version of the dataset |
+| `--set concepts` | A JSON array of the concept labels |
+
+To upload a dataset first, see the [Datasets documentation](https://docs.clarifai.com/create/datasets/). For all other init-time overrides (hyperparameters, base model, etc.), see the [Pipeline Templates reference](https://docs.clarifai.com/compute/pipelines/templates).
+
+### Monitor and Use the Trained Model
+
+* **Monitor the run** — see [Manage Pipeline Runs](https://docs.clarifai.com/compute/pipelines/manage-run).
+* **Deploy and run inference on the trained model** — see [Inference](https://docs.clarifai.com/compute/inference/).
+* **Author a custom pipeline from scratch in Python** — see the [Pipeline DSL reference](https://docs.clarifai.com/compute/pipelines/dsl-reference).
 
 ##  **Via the UI**
 
@@ -242,489 +289,6 @@ For this tutorial, uploading an image of a bean leaf will return classifications
 
 That’s it!
 
-##  **Via the CLI**
-
-:::note
-
-### Quick Start
-
-The [`classifier-pipeline-resnet-quick-start`](https://github.com/Clarifai/pipeline-examples/tree/main/classifier-pipeline-resnet-quick-start) template lets you train a test visual classification model with minimal setup. It uses a ResNet-based image classifier pre-configured with a public dataset, so you can run an end-to-end training pipeline immediately — no data preparation required.
-
-**Step 1: Perform Prerequisites**
-
-Before getting started, make sure you’ve completed the following setup:
-
-- Install the Clarifai package:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">pip install --upgrade clarifai</CodeBlock>
-</TabItem>
-</Tabs>
-
-- Authenticate your connection by setting your [Personal Access Token](https://docs.clarifai.com/control/authentication/pat) (PAT): 
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai login</CodeBlock>
-</TabItem>
-</Tabs>
-
-- Select an [instance type](https://docs.clarifai.com/compute/cloud-instances/) for running your pipeline — such as `g6e.xlarge`.
-
-
-**Step 2: Initialize a Pipeline from a Template**
-
-Initialize a new pipeline using the quick-start template, then navigate into the generated directory:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline init --template=classifier-pipeline-resnet-quick-start</CodeBlock>
-</TabItem>
-</Tabs>
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">cd classifier-pipeline-resnet-quick-start</CodeBlock>
-</TabItem>
-</Tabs>
-
-**Step 3: Upload and Run the Pipeline**
-
-Upload the pipeline configuration and execute the training job:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline upload</CodeBlock>
-</TabItem>
-</Tabs>
-
-> **Note:** This will automatically create an app called `pipeline-app` and upload the pipeline to it.
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline run --instance=g6e.xlarge</CodeBlock>
-</TabItem>
-</Tabs>
-
-**Step 4: Monitor Your Pipeline**
-
-Once the pipeline runs, it automatically loads the dataset, trains a ResNet-based image classifier, and produces a test model ready for use.
-
-To access your pipeline, open your app's sidebar and select **Pipelines**; to view your trained model, select **Models**.
-
-:::
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from "@theme/CodeBlock";
-
-
-import CodeDU from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/dataset_upload.py";
-
-import Output1 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-1.txt";
-import Output2 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-2.txt";
-import Output3 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-3.txt";
-import Output4 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-4.txt";
-import Output5 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-5.txt";
-import Output6 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-6.txt";
-import Output7 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-7.txt";
-import Output8 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-8.txt";
-import Output9 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-9.txt";
-import Output10 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-10.txt";
-import Output11 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/output-11.txt";
-
-import CodeMT from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/model_type.py";
-import CodeMC from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/model_creation.py";
-import CodeTS from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/template_selection.py";
-import CodeS from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/setup.py";
-import CodeS2 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/setup2.py";
-import CodeIMT from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/imt.py";
-import CodeMP from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_classifier/mp.py";
-import CodeTrEv from "!!raw-loader!../../../code_snippets/python-sdk/model_eval/visual_classifier/train_eval.py";
-import CodeTeEv from "!!raw-loader!../../../code_snippets/python-sdk/model_eval/visual_classifier/test_eval.py";
-import CodeCMP from "!!raw-loader!../../../code_snippets/python-sdk/model_eval/visual_classifier/cmp.py";
-
-import CodeOutputMT from "!!raw-loader!../../../code_snippets/python-sdk/model_training/outputs/visual_classifier/model_type.txt";
-import CodeOutputTS from "!!raw-loader!../../../code_snippets/python-sdk/model_training/outputs/visual_classifier/template_selection.txt";
-import CodeOutputS from "!!raw-loader!../../../code_snippets/python-sdk/model_training/outputs/visual_classifier/setup.txt";
-import CodeOutputS2 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/outputs/visual_classifier/setup2.txt";
-import CodeOutputIMT from "!!raw-loader!../../../code_snippets/python-sdk/model_training/outputs/visual_classifier/imt.txt";
-import CodeOutputMP from "!!raw-loader!../../../code_snippets/python-sdk/model_training/outputs/visual_classifier/mp.txt";
-import CodeOutputTrEv from "!!raw-loader!../../../code_snippets/python-sdk/model_eval/visual_classifier/outputs/train_eval.txt";
-import CodeOutputTeEv from "!!raw-loader!../../../code_snippets/python-sdk/model_eval/visual_classifier/outputs/test_eval.txt";
-import CodeOutputCMP from "!!raw-loader!../../../code_snippets/python-sdk/model_eval/visual_classifier/outputs/cmp.txt";
-
-import PythonCreateModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/create_model.py";
-import JSCreateModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/create_model.html";
-import NodeCreateModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/create_model.js";
-import JavaCreateModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/create_model.java";
-import PHPCreateModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/create_model.php";
-import CurlCreateModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/create_model.sh";
-
-import PythonTrainModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/train_model.py";
-import JSTrainModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/train_model.html";
-import NodeTrainModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/train_model.js";
-import JavaTrainModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/train_model.java";
-import PHPTrainModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/train_model.php";
-import CurlTrainModel from "!!raw-loader!../../../code_snippets/api-guide/model/deep_training/train_model.sh";
-
-<br/>
-
-Let’s walk through how to use the [Clarifai CLI](https://docs.clarifai.com/resources/api-overview/cli) to build and train a visual classification model using your own custom dataset
-
-### Step 1: Install Clarifai and Authenticate
-
-Start by installing the latest version of the `clarifai` Python package. This also includes the Clarifai CLI, which we’ll use to run and manage the training pipeline.
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">pip install --upgrade clarifai</CodeBlock>
-</TabItem>
-</Tabs>
-
-Then, authenticate your connection to Clarifai:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai login</CodeBlock>
-</TabItem>
-</Tabs>
-
-
-The CLI will prompt you for your [Personal Access Token](https://docs.clarifai.com/control/authentication/pat/) (PAT). It will auto-detect your user ID and save everything locally.
-
-> **Note:** You can obtain a PAT by opening **Settings** in the platform’s collapsible left sidebar, selecting **Secrets**, and then creating a new token or copying an existing one.
-
-
-### Step 2: Create an App
-
-Create an [app](https://docs.clarifai.com/create/applications/create/) to store and manage your model and its associated resources (such as datasets, pipelines, and deployments).
-
-
-<Tabs groupId="code">
-<TabItem value="python" label="CLI">
-    <CodeBlock className="language-python">clarifai app create your-app-id</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output1}</CodeBlock>
-</details>
-
-### Step 3: Prepare Training Data
-
-As mentioned [previously](#step-2-prepare-training-data), high-quality, well-structured data is critical for training an accurate and reliable model.
-
-For this example, we’ll use a public dataset of food images available [here](https://github.com/Clarifai/examples/tree/main/datasets/upload/image_classification/food-101/images). This dataset contains labeled images across multiple food categories, making it ideal for a classification task.
-
-:::info Objective
-
-Using this dataset, we’ll train a model to classify images into the following categories: `beignets`, `hamburger`, `prime_rib`, and `ramen`.
-
-:::
-
-You can clone the [repository](https://github.com/Clarifai/examples/tree/main) containing the dataset, then use the Clarifai Python SDK to [upload the dataset](https://docs.clarifai.com/create-manage/datasets/upload) to your app.
-
-
-<Tabs groupId="code">
-<TabItem value="python" label="Python SDK">
-    <CodeBlock className="language-python">{CodeDU}</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output2}</CodeBlock>
-</details>
-
-> **Note:** Once your dataset is successfully uploaded, navigate to the platform UI and record the `dataset_id` and `dataset_version_id`. You’ll need these values when running the training pipeline.
-
-
-### Step 4: Set Up Compute 
-
-You can run your pipeline using either on-demand instance compute or a managed cluster and nodepool.
-
-#### Option A: Select an Instance Type
-
-You can run your pipeline directly on on-demand compute by specifying an instance with the `--instance` flag (see [example below](#option-a-run-on-on-demand-instance-compute)). This removes the need to create and manage a cluster and nodepool.
-
-With this approach, compute is automatically provisioned—or reused if available — so you can focus on running your pipeline rather than managing infrastructure.
-
-See the [available instance types](https://docs.clarifai.com/compute/cloud-instances) to choose one that best matches your workload and performance requirements.
-
-#### Option B: Create a Cluster and Nodepool
-
-To train your model via the CLI with managed infrastructure, you’ll need to provision compute resources by creating a cluster and a nodepool.
-
-Start by defining a [YAML](https://docs.clarifai.com/compute/deployments/clusters-nodepools#1-compute_cluster_configyaml) configuration file for your compute cluster. Ensure the configuration supports GPU workloads, as GPUs are required for efficient training and inference of vision models.
-
-Here is an example cluster config file:
-
-<Tabs groupId="code">
-<TabItem value="yaml" label="YAML">
-```yaml
-compute_cluster:
-  id: "visual-compute-cluster"
-  description: "My AWS compute cluster"
-  cloud_provider:
-    id: "aws"
-  region: "us-east-1"
-  managed_by: "clarifai"
-  cluster_type: "dedicated"
-  visibility:
-    gettable: 10
-```
-</TabItem>
-</Tabs>
-
-Then run the following command, pointing to your config file:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-    clarifai computecluster create \
-      your_compute_cluster_id \
-      --config your_compute_cluster_config_filepath
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output3}</CodeBlock>
-</details>
-
-
-Next, define a nodepool within your cluster. This is where you specify the actual [compute instances](https://docs.clarifai.com/compute/cloud-instances) used for training. Be sure to choose a GPU-enabled instance that aligns with your performance and cost requirements.
-
-> **Note:** GPU support is essential for this tutorial. Without a compatible GPU instance, training may be significantly slower or fail altogether.
-
-Here is an example nodepool config file:
-
-<Tabs groupId="code">
-<TabItem value="yaml" label="YAML">
-```yaml
-nodepool:
-  id: "visual-nodepool"
-  compute_cluster:
-    id: "visual-compute-cluster"
-  description: "GPU nodepool for training workloads"
-  instance_types:
-    - id: "g5.2xlarge"
-      compute_info:
-        cpu_limit: "8"
-        cpu_memory: "28Gi"
-        accelerator_type:
-          - "a10"
-        num_accelerators: 1
-        accelerator_memory: "40Gi"
-  node_capacity_type:
-    capacity_types:
-      - 1
-  min_instances: 0
-  max_instances: 1
-```
-</TabItem>
-</Tabs>
-
-Then run the following command, pointing to your config file:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-    clarifai nodepool create \
-      your_compute_cluster_id \
-      your_nodepool_id \
-      --config your_nodepool_config_filepath
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output4}</CodeBlock>
-</details>
-
-
-### Step 5: Initialize a Pipeline from a Template
-
-The [`classifier-pipeline-resnet`](https://github.com/Clarifai/pipeline-examples/tree/main/classifier-pipeline-resnet) template lets you quickly set up a visual classification pipeline using a preconfigured ResNet-based image classifier — so you can focus on training rather than setup. It's one of several pipeline templates for common ML workflows; see the [Pipeline Templates](https://docs.clarifai.com/compute/pipelines/templates) page for the full list and how to discover what's available.
-
-Run the following command to scaffold a project from the template, pointing it at the dataset and concepts you set up in the previous steps:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    ```bash
-    clarifai pipeline init \
-      --app_id your_app_id \
-      --user_id your_user_id \
-      --template classifier-pipeline-resnet \
-      --set dataset_id=image_dataset \
-      --set dataset_version_id=dataset_version_id \
-      --set concepts='["beignets","hamburger","prime_rib","ramen"]'
-    ```
-</TabItem>
-</Tabs>
-
-The classifier-specific parameters above are:
-
-| Parameter | Description |
-|---|---|
-| `--set dataset_id` | The ID of the dataset to use for training |
-| `--set dataset_version_id` | The specific dataset version to use for training |
-| `--set concepts` | A JSON array of the concept labels the model will be trained to classify |
-
-For the full reference on `clarifai pipeline init` — including `--template`, `--set`, `--user_id`/`--app_id`, and overriding any other template default at init time — see the [Pipeline Templates](https://docs.clarifai.com/compute/pipelines/templates) page.
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output6}</CodeBlock>
-</details>
-
-Once executed, the command creates a project directory named after the template, preloaded with the necessary configuration files. Before running any subsequent `clarifai pipeline ...` commands, navigate into the generated directory:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">cd classifier-pipeline-resnet</CodeBlock>
-</TabItem>
-</Tabs>
-
-> **Note:** You can review the generated pipeline steps and tailor them to your use case — adjust default parameters, add dependencies to the `requirements.txt` files, or modify step logic. For an alternative, Python-first authoring path that lets you skip the scaffold-and-edit flow entirely, see the [Pipeline DSL reference](https://docs.clarifai.com/compute/pipelines/dsl-reference).
-
-### Step 6: Upload Your Pipeline
-
-Once your pipeline is initialized and configured, the next step is to upload it and trigger the training job.
-
-Make sure you’re inside the generated pipeline directory, then run:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline upload</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output7}</CodeBlock>
-</details>
-
-The above command will register the pipeline in your app, upload all associated configuration files, and prepare the pipeline for execution.
-
-### Step 7: Run the Pipeline
-
-You can run your pipeline using either on-demand instance compute or a preconfigured cluster and nodepool.
-
-#### Option A: Run on On-Demand Instance Compute
-
-Instead of relying on an existing nodepool and compute cluster, you can automatically provision or reuse compute at runtime by specifying an instance type:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline run --instance=g6e.xlarge</CodeBlock>
-</TabItem>
-</Tabs>
-
-This approach removes the need to manage infrastructure, making it ideal for quick experiments or simplified workflows.
-
-:::note Override Parameters at Runtime
-
-To modify pipeline parameters at run time, pass one or more `--set key=value` flags:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-clarifai pipeline run \
-  --instance=g6e.xlarge \
-  --set num_epochs=20 \
-  --set batch_size=32
-```
-</TabItem>
-</Tabs>
-
-:::
-
-#### Option B: Run on Cluster and Nodepool
-
-If you’ve already set up a compute cluster and nodepool, you can run the pipeline by explicitly targeting those resources:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-    clarifai pipeline run \
-      --nodepool_id=your_nodepool_id \
-      --compute_cluster_id=your_compute_cluster_id
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output8}</CodeBlock>
-</details>
-
-The above command launches the pipeline on your specified cluster and nodepool, ensuring it uses the configured GPU-backed resources.
-
-Once triggered, the pipeline runs end-to-end — loading the dataset, training the ResNet-based model, and producing a model ready for evaluation and further use.
-
-### Step 8: Monitor Your Pipeline
-
-To monitor your pipeline, open your app’s collapsible sidebar and select **Pipelines**. From there, navigate to the **Pipeline Version Runs** page, where you can track execution progress, view logs, and manage runs for a specific pipeline version — as illustrated [above](#step-7-train-the-model).
-
-To access the trained model, go to **Models** in the sidebar.
-
-You can also [monitor](https://docs.clarifai.com/compute/pipelines/manage-run#monitor-a-pipeline-run) the pipeline directly from the CLI:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipelinerun monitor pipeline_version_run_id</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output9}</CodeBlock>
-</details>
-
-### Step 9: Use Your Model
-
-Once training is complete, your model is ready for use. 
-
-Start by [creating a deployment](https://docs.clarifai.com/resources/api-overview/cli/#clarifai-model-deploy) to make it available for inference. 
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-clarifai model deploy \
-  --model-url clarifai_model_url \
-  --instance g5.2xlarge
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output10}</CodeBlock>
-</details>
-
-Then, use the generated deployment ID to run [predictions](https://docs.clarifai.com/resources/api-overview/cli/#clarifai-model-predict) on new data.
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-clarifai model predict \
-  clarifai_model_url \
-  --url https://samples.clarifai.com/featured-models/food-hamburgers-bacon-cheese.jpg \
-  --deployment deployment_id
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output11}</CodeBlock>
-</details>
 
 <!--
 

--- a/docs/create/models/visual-detector.md
+++ b/docs/create/models/visual-detector.md
@@ -17,38 +17,86 @@ A visual detector is a deep fine-tuned model that identifies and localizes objec
 
 For example, it can be used to detect and locate objects such as "car", "person", or "dog" within an image, drawing a bounding box around each identified instance.
 
-:::note pipeline template
-
-A pipeline template is a pre-configured workflow that defines how a model is trained, evaluated, and deployed.
-
-It is built on top of [Clarifai Pipelines](https://docs.clarifai.com/compute/pipelines/), which are the underlying system that orchestrates a sequence of steps (nodes) such as data processing, training, and evaluation. The template simply provides a ready-made, opinionated setup of these pipelines for a specific use case.
-
-Instead of building everything from scratch, a pipeline template gives you a ready-made structure with:
-
-* **Predefined steps** (e.g., data loading, preprocessing, training, evaluation)
-* **Default configurations** (such as model architecture and training logic)
-* **Tunable parameters** (hyperparameters you can adjust to fit your use case)
-
-In practical terms, it acts as a blueprint for your training process. For example, when you select the [`detector-pipeline-yolof`](#select-training-template) template, you're choosing:
-
-* A pipeline designed for object detection
-* A YOLOF-based model architecture
-* A sequence of steps already wired together using Clarifai Pipelines to train on images with bounding box annotations
-
-:::
-
-
-You may choose a visual detector model type in cases where:
-
-- **Accuracy takes priority** — you need precise object localization rather than a fast, general-purpose solution.
-- **Your data is unique** — existing Clarifai models don't detect the objects in your dataset, and you need to deep fine-tune a custom model integrated into your workflows.
-- **You have the right ingredients** — a custom dataset with bounding box annotations, and the time and expertise to fine-tune.
+Use a visual detector when you have a labeled dataset with bounding-box annotations and want a custom model fine-tuned on your own object classes.
 
 :::tip
 
 Visual detectors are optimized for detection and localization tasks. If you only need to identify *what* is in an image without locating specific objects, consider a [Visual Classifier](visual-classifier.md) instead.
 
 :::
+
+You can train a visual detector two ways:
+
+- **[Via the CLI](#via-the-cli)** — Scriptable and reproducible. Recommended for engineering workflows. Train an end-to-end model in three commands.
+- **[Via the UI](#via-the-ui)** — Click-through training from the Clarifai web app. Recommended for quick experiments without writing code.
+
+##  **Via the CLI**
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from "@theme/CodeBlock";
+
+### Prerequisites
+
+Install the Clarifai CLI and authenticate:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{`pip install --upgrade clarifai
+clarifai login`}</CodeBlock>
+</TabItem>
+</Tabs>
+
+`clarifai login` auto-detects your user ID and saves your [Personal Access Token (PAT)](https://docs.clarifai.com/control/authentication/pat/) locally.
+
+### Train a Detector (Quick Demo)
+
+The fastest way to see a working detector end-to-end is the [`detector-pipeline-yolof-quick-start`](https://github.com/Clarifai/pipeline-examples/tree/main/detector-pipeline-yolof-quick-start) template. It uses a Clarifai-hosted public dataset as the training data, with sensible defaults for every hyperparameter — so no dataset setup or `--set` flags are required.
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{`clarifai pipeline init --template detector-pipeline-yolof-quick-start
+cd detector-pipeline-yolof-quick-start
+clarifai pipeline upload
+clarifai pipeline run --instance=g6e.xlarge`}</CodeBlock>
+</TabItem>
+</Tabs>
+
+That's it. `--instance=g6e.xlarge` auto-provisions a compute cluster and nodepool — no separate setup required. The pipeline trains a YOLOF object detector on the public dataset and registers the trained model in your Clarifai model registry.
+
+### Train on Your Own Data
+
+When you want to train a detector on your own object classes, use the [`detector-pipeline-yolof`](https://github.com/Clarifai/pipeline-examples/tree/main/detector-pipeline-yolof) template with `--set` flags pointing at your uploaded dataset:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+```bash
+clarifai pipeline init --template detector-pipeline-yolof \
+  --set dataset_id=your_dataset_id \
+  --set dataset_version_id=your_dataset_version_id \
+  --set concepts='["class1","class2","..."]'
+cd detector-pipeline-yolof
+clarifai pipeline upload
+clarifai pipeline run --instance=g6e.xlarge
+```
+</TabItem>
+</Tabs>
+
+Where:
+
+| Parameter | Description |
+|---|---|
+| `--set dataset_id` | The ID of the dataset to train on (with bounding-box annotations) |
+| `--set dataset_version_id` | The specific version of the dataset |
+| `--set concepts` | A JSON array of the object class labels |
+
+To upload a dataset first, see the [Datasets documentation](https://docs.clarifai.com/create/datasets/). For all other init-time overrides (hyperparameters, base model, etc.), see the [Pipeline Templates reference](https://docs.clarifai.com/compute/pipelines/templates).
+
+### Monitor and Use the Trained Model
+
+* **Monitor the run** — see [Manage Pipeline Runs](https://docs.clarifai.com/compute/pipelines/manage-run).
+* **Deploy and run inference on the trained model** — see [Inference](https://docs.clarifai.com/compute/inference/).
+* **Author a custom pipeline from scratch in Python** — see the [Pipeline DSL reference](https://docs.clarifai.com/compute/pipelines/dsl-reference).
 
 ##  **Via the UI**
 
@@ -238,515 +286,4 @@ After deployment, click the **Try Model** button in the upper-right corner to op
 For this tutorial, uploading an image will return detected objects with bounding boxes drawn around each identified item — labeled with their concept such as `Coverall`, `Gloves`, or `Mask` — along with their prediction probabilities.
 
 That's it!
-
-##  **Via the CLI**
-
-:::note
-
-### Quick Start
-
-The [`detector-pipeline-yolof-quick-start`](https://github.com/Clarifai/pipeline-examples/tree/main/detector-pipeline-yolof-quick-start) template lets you train a test visual detection model with minimal setup. It uses a YOLOF-based object detector pre-configured with a public dataset, so you can run an end-to-end training pipeline immediately — no data preparation required.
-
-**Step 1: Perform Prerequisites**
-
-Before getting started, make sure you've completed the following setup:
-
-- Install the Clarifai package:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">pip install --upgrade clarifai</CodeBlock>
-</TabItem>
-</Tabs>
-
-- Authenticate your connection by setting your [Personal Access Token](https://docs.clarifai.com/control/authentication/pat) (PAT): 
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai login</CodeBlock>
-</TabItem>
-</Tabs>
-
-- Select an [instance type](https://docs.clarifai.com/compute/cloud-instances/) for running your pipeline — such as `g6e.xlarge`.
-
-
-**Step 2: Initialize a Pipeline from a Template**
-
-Initialize a new pipeline using the quick-start template, then navigate into the generated directory:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline init --template=detector-pipeline-yolof-quick-start</CodeBlock>
-</TabItem>
-</Tabs>
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">cd detector-pipeline-yolof-quick-start</CodeBlock>
-</TabItem>
-</Tabs>
-
-**Step 3: Upload and Run the Pipeline**
-
-Upload the pipeline configuration and execute the training job:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline upload</CodeBlock>
-</TabItem>
-</Tabs>
-
-> **Note:** This will automatically create an app called `pipeline-app` and upload the pipeline to it.
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline run --instance=g6e.xlarge</CodeBlock>
-</TabItem>
-</Tabs>
-
-**Step 4: Monitor Your Pipeline**
-
-Once the pipeline runs, it automatically loads the dataset, trains a YOLOF-based object detector, and produces a test model ready for use.
-
-To access your pipeline, open your app's sidebar and select **Pipelines**; to view your trained model, select **Models**.
-
-:::
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import CodeBlock from "@theme/CodeBlock";
-
-
-import CodeDU from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/dataset_upload.py";
-
-import Output1 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-1.txt";
-import Output2 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-2.txt";
-import Output3 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-3.txt";
-import Output4 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-4.txt";
-import Output5 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-5.txt";
-import Output6 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-6.txt";
-import Output7 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-7.txt";
-import Output8 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-8.txt";
-import Output9 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-9.txt";
-import Output10 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-10.txt";
-import Output11 from "!!raw-loader!../../../code_snippets/python-sdk/model_training/visual_detector/output-11.txt";
-
-<br/>
-
-Let's walk through how to use the [Clarifai CLI](https://docs.clarifai.com/resources/api-overview/cli) to build and train a visual detection model using your own custom dataset.
-
-### Step 1: Install Clarifai and Authenticate
-
-Start by installing the latest version of the `clarifai` Python package. This also includes the Clarifai CLI, which we'll use to run and manage the training pipeline.
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">pip install --upgrade clarifai</CodeBlock>
-</TabItem>
-</Tabs>
-
-Then, authenticate your connection to Clarifai:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai login</CodeBlock>
-</TabItem>
-</Tabs>
-
-The CLI will prompt you for your [Personal Access Token](https://docs.clarifai.com/control/authentication/pat/) (PAT). It will auto-detect your user ID and save everything locally.
-
-> **Note:** You can obtain a PAT by opening **Settings** in the platform's collapsible left sidebar, selecting **Secrets**, and then creating a new token or copying an existing one.
-
-
-### Step 2: Create an App
-
-Create an [app](https://docs.clarifai.com/create/applications/create/) to store and manage your model and its associated resources (such as datasets, pipelines, and deployments).
-
-<Tabs groupId="code">
-<TabItem value="python" label="CLI">
-    <CodeBlock className="language-python">clarifai app create your-app-id</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output1}</CodeBlock>
-</details>
-
-### Step 3: Prepare Training Data
-
-As mentioned [previously](#step-2-prepare-training-data), high-quality, well-structured data is critical for training an accurate and reliable model.
-
-For object detection, your dataset must include images with bounding box annotations. Each annotation marks the location of an object in the image and assigns it a concept label.
-
-For this example, we'll use the detection dataset from the [Clarifai examples repository](https://github.com/Clarifai/examples/tree/main/datasets/upload/image_detection). Specifically, we'll use the VOC format variant (`voc/`), which includes:
-
-- 10 images sourced from the Pascal VOC dataset
-- XML annotation files (one per image) containing bounding box coordinates and concept labels in PASCAL VOC format
-- A `dataset.py` file with a `VOCDetectionDataLoader` class that handles parsing and uploading
-
-The dataset directory structure looks like this:
-
-```
-image_detection/
-└── voc/
-    ├── dataset.py          # DataLoader implementation
-    ├── images/             # 10 .jpg images
-    └── annotations/        # 10 .xml bounding box annotation files
-```
-
-:::info Objective
-
-Using this dataset, we'll train a model to detect and localize the following object categories: `bird`, `bottle`, `cat`, `cow`, `dog`, `horse`, `person`, and `sofa`.
-
-:::
-
-Start by cloning the [Clarifai examples repository](https://github.com/Clarifai/examples):
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    ```bash
-    git clone https://github.com/Clarifai/examples.git
-    ```
-</TabItem>
-</Tabs>
-
-Then use the Clarifai Python SDK to [upload the dataset](https://docs.clarifai.com/create-manage/datasets/upload) to your app.
-
-<Tabs groupId="code">
-<TabItem value="python" label="Python SDK">
-    <CodeBlock className="language-python">{CodeDU}</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output2}</CodeBlock>
-</details>
-
-> **Note:** Once your dataset is successfully uploaded, navigate to the platform UI and record the `dataset_id` and `dataset_version_id`. You'll need these values when running the training pipeline.
-
-
-### Step 4: Set Up Compute 
-
-You can run your pipeline using either on-demand instance compute or a managed cluster and nodepool.
-
-#### Option A: Select an Instance Type
-
-You can run your pipeline directly on on-demand compute by specifying an instance with the `--instance` flag (see [example below](#option-a-run-on-on-demand-instance-compute)). This removes the need to create and manage a cluster and nodepool.
-
-With this approach, compute is automatically provisioned — or reused if available — so you can focus on running your pipeline rather than managing infrastructure.
-
-See the [available instance types](https://docs.clarifai.com/compute/cloud-instances) to choose one that best matches your workload and performance requirements.
-
-#### Option B: Create a Cluster and Nodepool
-
-To train your model via the CLI with managed infrastructure, you'll need to provision compute resources by creating a cluster and a nodepool.
-
-Start by defining a [YAML](https://docs.clarifai.com/compute/deployments/clusters-nodepools#1-compute_cluster_configyaml) configuration file for your compute cluster. Ensure the configuration supports GPU workloads, as GPUs are required for efficient training and inference of detection models.
-
-Here is an example cluster config file:
-
-<Tabs groupId="code">
-<TabItem value="yaml" label="YAML">
-```yaml
-compute_cluster:
-  id: "visual-compute-cluster"
-  description: "My AWS compute cluster"
-  cloud_provider:
-    id: "aws"
-  region: "us-east-1"
-  managed_by: "clarifai"
-  cluster_type: "dedicated"
-  visibility:
-    gettable: 10
-```
-</TabItem>
-</Tabs>
-
-Then run the following command, pointing to your config file:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-    clarifai computecluster create \
-      your_compute_cluster_id \
-      --config your_compute_cluster_config_filepath
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output3}</CodeBlock>
-</details>
-
-
-Next, define a nodepool within your cluster. This is where you specify the actual [compute instances](https://docs.clarifai.com/compute/cloud-instances) used for training. Be sure to choose a GPU-enabled instance that aligns with your performance and cost requirements.
-
-> **Note:** GPU support is essential for this tutorial. Without a compatible GPU instance, training may be significantly slower or fail altogether.
-
-Here is an example nodepool config file:
-
-<Tabs groupId="code">
-<TabItem value="yaml" label="YAML">
-```yaml
-nodepool:
-  id: "visual-nodepool"
-  compute_cluster:
-    id: "visual-compute-cluster"
-  description: "GPU nodepool for training workloads"
-  instance_types:
-    - id: "g5.2xlarge"
-      compute_info:
-        cpu_limit: "8"
-        cpu_memory: "28Gi"
-        accelerator_type:
-          - "a10"
-        num_accelerators: 1
-        accelerator_memory: "40Gi"
-  node_capacity_type:
-    capacity_types:
-      - 1
-  min_instances: 0
-  max_instances: 1
-```
-</TabItem>
-</Tabs>
-
-Then run the following command, pointing to your config file:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-    clarifai nodepool create \
-      your_compute_cluster_id \
-      your_nodepool_id \
-      --config your_nodepool_config_filepath
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output4}</CodeBlock>
-</details>
-
-
-### Step 5: Initialize a Pipeline from a Template
-
-The [`detector-pipeline-yolof`](https://github.com/Clarifai/pipeline-examples/tree/main/detector-pipeline-yolof) template lets you quickly set up a visual detection pipeline using a preconfigured YOLOF-based object detector — so you can focus on training rather than setup.
-
-:::tip
-
-To view all the available predefined templates, run:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipelinetemplate list</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output5}</CodeBlock>
-</details>
-
-:::
- 
-Run the following command to [initialize a pipeline](https://docs.clarifai.com/compute/pipelines/create-api#step-2-initialize-a-pipeline-project) from the template:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    ```bash
-    clarifai pipeline init \
-      --app_id your_app_id \
-      --user_id your_user_id \
-      --template detector-pipeline-yolof \
-      --set dataset_id=image_dataset \
-      --set dataset_version_id=dataset_version_id \
-      --set concepts='["bird","bottle","cat","cow","dog","horse","person","sofa"]'
-    ```
-</TabItem>
-</Tabs>
-
-Where:
-
-| Parameter | Description |
-|---|---|
-| `--app_id` | The ID of the app where the pipeline will be created |
-| `--user_id` | Your Clarifai user ID |
-| `--template` | The pipeline template to use. Here, we use `detector-pipeline-yolof` |
-| `--set dataset_id` | The ID of the dataset to use for training |
-| `--set dataset_version_id` | The specific dataset version to use for training |
-| `--set concepts` | A JSON array of the concept labels the model will be trained to detect |
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output6}</CodeBlock>
-</details>
-
-Once executed, the command creates a new project directory named after the template, preloaded with all necessary configuration files.
-
-Before running any subsequent `clarifai pipeline ...` commands, navigate into the generated directory — these commands rely on the local `config.yaml` and `config-lock.yaml` files:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">cd detector-pipeline-yolof</CodeBlock>
-</TabItem>
-</Tabs>
-
-> **Note:** You can optionally review the generated pipeline steps and tailor them to your use case. If needed, you can also adjust the default parameters and add any additional dependencies to the `requirements.txt` files to support your pipeline.
-
-:::tip Override Defaults at Initialization
-
-You can optionally customize the pipeline during setup — for example, by specifying a different user/app, assigning a custom pipeline ID, or adjusting model parameters:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-  clarifai pipeline init --template=detector-pipeline-yolof \
-  --user_id your_custom_user_id \
-  --app_id your_custom_app_id \
-  --set id=your_custom_pipeline_id \
-  --set num_epochs=20
-```
-</TabItem>
-</Tabs>
-
-
-:::
-
-### Step 6: Upload Your Pipeline
-
-Once your pipeline is initialized and configured, the next step is to upload it and trigger the training job.
-
-Make sure you're inside the generated pipeline directory, then run:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline upload</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output7}</CodeBlock>
-</details>
-
-The above command will register the pipeline in your app, upload all associated configuration files, and prepare the pipeline for execution.
-
-### Step 7: Run the Pipeline
-
-You can run your pipeline using either on-demand instance compute or a preconfigured cluster and nodepool.
-
-#### Option A: Run on On-Demand Instance Compute
-
-Instead of relying on an existing nodepool and compute cluster, you can automatically provision or reuse compute at runtime by specifying an instance type:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipeline run --instance=g6e.xlarge</CodeBlock>
-</TabItem>
-</Tabs>
-
-This approach removes the need to manage infrastructure, making it ideal for quick experiments or simplified workflows.
-
-:::note Override Parameters at Runtime
-
-To modify pipeline parameters at run time, pass one or more `--set key=value` flags:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-clarifai pipeline run \
-  --instance=g6e.xlarge \
-  --set num_epochs=20 \
-  --set batch_size=32
-```
-</TabItem>
-</Tabs>
-
-:::
-
-#### Option B: Run on Cluster and Nodepool
-
-If you've already set up a compute cluster and nodepool, you can run the pipeline by explicitly targeting those resources:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-    clarifai pipeline run \
-      --nodepool_id=your_nodepool_id \
-      --compute_cluster_id=your_compute_cluster_id
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output8}</CodeBlock>
-</details>
-
-The above command launches the pipeline on your specified cluster and nodepool, ensuring it uses the configured GPU-backed resources.
-
-Once triggered, the pipeline runs end-to-end — loading the dataset, training the YOLOF-based model, and producing a model ready for evaluation and further use.
-
-### Step 8: Monitor Your Pipeline
-
-To monitor your pipeline, open your app's collapsible sidebar and select **Pipelines**. From there, navigate to the **Pipeline Version Runs** page, where you can track execution progress, view logs, and manage runs for a specific pipeline version — as illustrated [above](#step-7-train-the-model).
-
-To access the trained model, go to **Models** in the sidebar.
-
-You can also [monitor](https://docs.clarifai.com/compute/pipelines/manage-run#monitor-a-pipeline-run) the pipeline directly from the CLI:
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai pipelinerun monitor pipeline_version_run_id</CodeBlock>
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output9}</CodeBlock>
-</details>
-
-### Step 9: Use Your Model
-
-Once training is complete, your model is ready for use. 
-
-Start by [creating a deployment](https://docs.clarifai.com/resources/api-overview/cli/#clarifai-model-deploy) to make it available for inference. 
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-clarifai model deploy \
-  --model-url clarifai_model_url \
-  --instance g5.2xlarge
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output10}</CodeBlock>
-</details>
-
-Then, use the generated deployment ID to run [predictions](https://docs.clarifai.com/resources/api-overview/cli/#clarifai-model-predict) on new data.
-
-<Tabs groupId="code">
-<TabItem value="bash" label="CLI">
-```bash
-clarifai model predict \
-  clarifai_model_url \
-  --url https://samples.clarifai.com/featured-models/person-vehicle-man-crossing-street-mask-japan.jpg \
-  --deployment deployment_id
-```
-</TabItem>
-</Tabs>
-
-<details>
-  <summary>Example Output</summary>
-    <CodeBlock className="language-python">{Output11}</CodeBlock>
-</details>
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -132,37 +132,11 @@ Congratulations — you've just gotten started with the Clarifai platform!
 
 :::
 
-## Step 6: Orchestrate Multi-Step Workflows with Pipelines
+## What to Explore Next
 
-For asynchronous, long-running, multi-step workflows — model training, fine-tuning, data preparation, batch processing, agent orchestration — use [Clarifai Pipelines](https://docs.clarifai.com/compute/pipelines/). You can define an entire pipeline in Python, no YAML required:
+You've made your first inference call. Here are some directions to explore from here:
 
-```python
-from clarifai.runners.pipelines import ComputeInfo, Pipeline, step
-
-@step(id="prepare", compute=ComputeInfo(cpu_limit="500m", cpu_memory="500Mi"))
-def prepare(input_text: str) -> str:
-    return input_text.strip().lower()
-
-@step(id="summarize")
-def summarize(input_text: str) -> str:
-    return input_text[:80]
-
-with Pipeline(id="my-first-pipeline", user_id="YOUR_USER_ID", app_id="YOUR_APP_ID") as pipeline:
-    raw = pipeline.input("input_text", default="Hello, Clarifai pipelines!")
-
-    prepared = prepare(input_text=raw)
-    summary = summarize(input_text=prepared.output())
-
-    prepared >> summary
-```
-
-Then upload and run, directly from the `.py` file:
-
-<Tabs groupId="code">
-<TabItem value="bash3" label="CLI">
-    <CodeBlock className="language-bash">{`clarifai pipeline upload my_pipeline.py
-clarifai pipeline run --pipeline_id my-first-pipeline`}</CodeBlock>
-</TabItem>
-</Tabs>
-
-For the full walkthrough — including step composition with the `>>` operator, referencing existing remote steps, pipeline templates, and the YAML / config-based authoring path — see the [Pipelines documentation](https://docs.clarifai.com/compute/pipelines/).
+- **[Deploy your own model](https://docs.clarifai.com/compute/deployments/)** — Run inference on dedicated GPUs with your own model.
+- **[Train a model](https://docs.clarifai.com/create/models/)** — Fine-tune a classifier, detector, or LLM on your data using a pipeline template.
+- **[Build orchestration pipelines](https://docs.clarifai.com/compute/pipelines/)** — Define multi-step, long-running workflows in Python — training, evaluation, agent orchestration, batch processing.
+- **[Use the OpenAI-compatible API](https://docs.clarifai.com/compute/inference/open-ai/)** — Same endpoint, OpenAI client library.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -131,3 +131,38 @@ Congratulations — you've just gotten started with the Clarifai platform!
 [Click here](https://docs.clarifai.com/compute/models/inference/api/) to learn more about how to make inference requests using our API. You'll discover how to list all the available inference methods defined in a model's configuration, generate example code, leverage our Compute Orchestration capabilities for various types of inference requests, and more.
 
 :::
+
+## Step 6: Orchestrate Multi-Step Workflows with Pipelines
+
+For asynchronous, long-running, multi-step workflows — model training, fine-tuning, data preparation, batch processing, agent orchestration — use [Clarifai Pipelines](https://docs.clarifai.com/compute/pipelines/). You can define an entire pipeline in Python, no YAML required:
+
+```python
+from clarifai.runners.pipelines import ComputeInfo, Pipeline, step
+
+@step(id="prepare", compute=ComputeInfo(cpu_limit="500m", cpu_memory="500Mi"))
+def prepare(input_text: str) -> str:
+    return input_text.strip().lower()
+
+@step(id="summarize")
+def summarize(input_text: str) -> str:
+    return input_text[:80]
+
+with Pipeline(id="my-first-pipeline", user_id="YOUR_USER_ID", app_id="YOUR_APP_ID") as pipeline:
+    raw = pipeline.input("input_text", default="Hello, Clarifai pipelines!")
+
+    prepared = prepare(input_text=raw)
+    summary = summarize(input_text=prepared.output())
+
+    prepared >> summary
+```
+
+Then upload and run, directly from the `.py` file:
+
+<Tabs groupId="code">
+<TabItem value="bash3" label="CLI">
+    <CodeBlock className="language-bash">{`clarifai pipeline upload my_pipeline.py
+clarifai pipeline run --pipeline_id my-first-pipeline`}</CodeBlock>
+</TabItem>
+</Tabs>
+
+For the full walkthrough — including step composition with the `>>` operator, referencing existing remote steps, pipeline templates, and the YAML / config-based authoring path — see the [Pipelines documentation](https://docs.clarifai.com/compute/pipelines/).


### PR DESCRIPTION
# PR 2 — Wire dependent docs into the new Python-first pipelines structure

**Branch:** `alfredo/pipelines-dependent-docs-update` (local draft, in `~/Dev/clarifai/docs-pr-pipelines-pythonic` worktree)
**Base:** `origin/main` at `15a113337f`
**Commit:** `38ef9ed5e5`
**Changes:** +44 / -48 across 2 files
**Depends on:** `alfredo/pipelines-pythonic-restructure` being merged first (inbound links won't resolve until then)

## Summary

* Rewrites visual-classifier's "Step 5: Initialize a Pipeline from a Template" as a short workflow step that links into the canonical pipelines docs instead of re-documenting engine-level commands inline.
* Adds a "Step 6: Orchestrate Multi-Step Workflows with Pipelines" section to the site-level quickstart, leading with the Python DSL.

## Context

Companion to `alfredo/pipelines-pythonic-restructure`. Together, the two PRs land the IA proposal from the 2026-05-15 pipelines docs audit: make `/compute/pipelines/` the canonical home for engine-level pipeline content (DSL, templates, CLI reference), and have model-type guides and the site-level quickstart link *into* it rather than duplicate.

## Changes

* **`docs/create/models/visual-classifier.md`** — Step 5 rewrite. Keeps the classifier-specific init command (the value-add of this page) and the classifier-specific `--set` parameter table (`dataset_id`, `dataset_version_id`, `concepts`). Drops the generic `pipelinetemplate list` tip and the generic "Override Defaults at Initialization" tip, both now canonical at `/compute/pipelines/templates`. Drops the generic parameter description table (rows for `--app_id`, `--user_id`, `--template`), keeping only the classifier-specific rows. Adds a link to the canonical Templates page for the full init reference, and a link to the new Pipeline DSL reference as the alternative Python-first authoring path.
* **`docs/getting-started/quickstart.md`** — New "Step 6: Orchestrate Multi-Step Workflows with Pipelines" section added after the existing Step 5 (model inference). Distills the DSL quickstart into ~10 lines of working Python plus the upload/run commands, with a link into the full pipelines docs.

## Decisions to confirm with you

1. **Visual-classifier scope** — I kept Step 5 focused on the classifier-specific init command and dropped the generic engine-level coverage. The intent is that model-type guides become workflow walkthroughs that link into canonical pipelines docs for engine-level reference. Confirm that's the right level of trimming, or push back if you want more of the original Step 5 content preserved here for self-containment.
2. **Site-level quickstart placement** — added as "Step 6" after the model-inference step. You'd said "after CO parts for model inference," which I interpreted as right after the existing Step 5. If you want it as a sibling section ("After Quickstart, try…") instead of a numbered step, easy to switch.
3. **Site quickstart code length** — ~10 lines of DSL. Brief enough that it stays in the quickstart spirit. If you want it shorter (5-line teaser linking out) or longer (mini-walkthrough with output), say.

## What this PR does *not* do

* Doesn't touch other model-type guides (`visual-detector.md`, etc.) — they don't currently have the same template-init duplication that visual-classifier had. If/when LoRA, detector, or benchmark guides are written, the same pattern (link into canonical pipelines docs) should be the default.
* Doesn't add a new top-level pipelines entry point — the site quickstart's Step 6 links into `/compute/pipelines/`, which itself leads with the DSL quickstart from PR 1.

## How to preview locally

```bash
cd ~/Dev/clarifai/docs-pr-pipelines-pythonic
git checkout alfredo/pipelines-dependent-docs-update
# preview with usual docs build
```

To preview both PRs together (since this one depends on PR 1's inbound link targets existing):

```bash
git checkout alfredo/pipelines-pythonic-restructure
git merge alfredo/pipelines-dependent-docs-update
# preview
```

## Linked

* PR 1: `alfredo/pipelines-pythonic-restructure` — canonical `/compute/pipelines/` restructure (DSL quickstart, DSL reference, templates page, `create-api.md` demotion, artifacts cross-link). Merge first.
* Audit: `~/Dev/work/product/pipelines/cli_docs_audit.md` — full background including your earlier corrections and the DSL finding.
