### PR TITLE
Reflect Pete's pipeline DSL extensions in /compute/pipelines/

### DIFF
--- a/docs/compute/pipelines/README.mdx
+++ b/docs/compute/pipelines/README.mdx
@@ -89,6 +89,18 @@ The pipeline fine-tunes the model on a single-GPU instance (the template's compu
 
 That's it — you have a fine-tuned model registered in your Clarifai model registry, ready to serve, evaluate, or refine further.
 
+:::tip Python-first alternative
+
+The LoRA template ships with both a YAML scaffold (`config.yaml`) and a Python DSL form (`dsl.py`). To upload directly from the DSL Python file instead of the scaffold:
+
+```bash
+clarifai pipeline upload dsl.py
+```
+
+Both paths produce the same pipeline. The DSL form is the recommended starting point if you plan to author your own custom pipelines — see the [Pipeline DSL reference](dsl-reference.md) for the full API (`@step`, `step_ref`, `>>` composition, `base_image`, etc.).
+
+:::
+
 ### Customize Before Running
 
 To override defaults at init time, pass `--set key=value` flags. For example, to fine-tune a different base model and change the number of epochs:

--- a/docs/compute/pipelines/dsl-reference.md
+++ b/docs/compute/pipelines/dsl-reference.md
@@ -56,6 +56,8 @@ def prepare_text(input_text: str) -> str:
 | `assets` | `list[str]` | Files or directories to bundle alongside the step's code. Paths are resolved relative to the source file containing the step. |
 | `compute` | `ComputeInfo` | Compute resources for the step (CPU, memory, accelerators). See [Compute Requirements](#compute-requirements). |
 | `python_version` | `str` | Python version to use inside the step's container. Defaults to `"3.12"`. |
+| `base_image` | `Optional[str]` | Custom base Docker image for the step's container — e.g., a CUDA-enabled image for GPU steps. Defaults to Clarifai's standard base image. |
+| `platform` | `Optional[str]` | Build platform for the step's container image (e.g., `"linux/amd64"`). Defaults to multi-architecture build. |
 | `secrets` | `dict[str, str]` | Environment variable name → secret resource path. Secrets are mounted as environment variables at step runtime. |
 
 ### Step Input Parameters


### PR DESCRIPTION
## Summary

Small follow-up to [#877](https://github.com/Clarifai/docs/pull/877) reflecting two `clarifai-python` / `pipeline-examples` PRs that merged on 2026-05-21:

- [`clarifai-python#1044`](https://github.com/Clarifai/clarifai-python/pull/1044) — adds \`base_image\` and \`platform\` kwargs to the \`@step\` decorator. Enables CUDA-enabled base images for GPU steps and platform-specific builds.
- [`pipeline-examples#33`](https://github.com/Clarifai/pipeline-examples/pull/33) — adds \`dsl.py\` alongside \`config.yaml\` in the \`lora-pipeline-unsloth-quick-start\` template. The template now ships both a YAML scaffold and a Python DSL form.

These changes landed after PR #877 was merged, so they need a separate small PR.

## Changes

- **dsl-reference.md** — add \`base_image\` and \`platform\` rows to the \`@step\` parameter table.
- **README.mdx Quick Start** — add a \"Python-first alternative\" \`:::tip\` note pointing readers at \`clarifai pipeline upload dsl.py\` as the recommended starting point for custom-pipeline authors. The default Quick Start still leads with \`clarifai pipeline upload\` (the scaffold path) since it's what most readers will copy-paste; the DSL form is surfaced as the equally-supported alternative.

## Test plan

- [ ] Verify the new \`base_image\` / \`platform\` rows render correctly in the DSL reference table.
- [ ] Verify the Python-first alternative tip renders correctly in the Quick Start.
- [ ] (Optional) Spot-check that \`clarifai pipeline upload dsl.py\` works against the live \`lora-pipeline-unsloth-quick-start\` template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)