### PR TITLE
Add 'Fine-Tune Your First LLM' to Getting Started

### DIFF
--- a/docs/getting-started/fine-tune-your-first-llm.md
+++ b/docs/getting-started/fine-tune-your-first-llm.md
@@ -1,0 +1,68 @@
+---
+description: Fine-tune an LLM with LoRA in three commands using a pipeline template
+sidebar_position: 5
+---
+
+# Fine-Tune Your First LLM
+
+**Fine-tune an LLM with LoRA in three commands using a pipeline template**
+<hr />
+
+The fastest way to fine-tune an LLM on Clarifai is to scaffold a project from the [`lora-pipeline-unsloth-quick-start`](https://github.com/Clarifai/pipeline-examples/tree/main/lora-pipeline-unsloth-quick-start) pipeline template, then upload and run it. The template uses public data, sensible defaults, and auto-provisions compute — no dataset setup or hyperparameter tuning required for the first run.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from "@theme/CodeBlock";
+
+## Prerequisites
+
+Install the Clarifai CLI and authenticate:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{`pip install --upgrade clarifai
+clarifai login`}</CodeBlock>
+</TabItem>
+</Tabs>
+
+`clarifai login` auto-detects your user ID and saves your [Personal Access Token (PAT)](https://docs.clarifai.com/control/authentication/pat/) locally.
+
+## Fine-Tune the Model
+
+Scaffold a project from the LoRA quick-start template, then upload and run it:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{`clarifai pipeline init --template lora-pipeline-unsloth-quick-start
+cd lora-pipeline-unsloth-quick-start
+clarifai pipeline upload
+clarifai pipeline run --instance=g5.xlarge`}</CodeBlock>
+</TabItem>
+</Tabs>
+
+This trains a LoRA fine-tune of [`unsloth/Qwen3-0.6B`](https://huggingface.co/unsloth/Qwen3-0.6B) on the [`mlabonne/FineTome-100k`](https://huggingface.co/datasets/mlabonne/FineTome-100k) dataset using [Unsloth](https://github.com/unslothai/unsloth). `--instance=g5.xlarge` auto-provisions a compute cluster and nodepool — no separate cluster setup required, and the same nodepool can later serve inference on the fine-tuned model.
+
+When training completes, the fine-tuned model is registered in your Clarifai model registry, ready to serve, evaluate, or refine further.
+
+## Customize Before Running
+
+To override defaults at init time — a different base model, more epochs, custom LoRA rank — pass `--set key=value` flags. For example, to fine-tune Llama 3.2 1B for three epochs:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+```bash
+clarifai pipeline init --template lora-pipeline-unsloth-quick-start \
+  --set base_model_name="unsloth/Llama-3.2-1B-Instruct" \
+  --set num_epochs=3
+```
+</TabItem>
+</Tabs>
+
+See the [Pipeline Templates reference](https://docs.clarifai.com/compute/pipelines/templates) for all customizable parameters.
+
+## What to Explore Next
+
+- **[Train a Visual Classifier](https://docs.clarifai.com/create/models/visual-classifier)** — Train an image classifier (ResNet) using a different pipeline template.
+- **[Train a Visual Detector](https://docs.clarifai.com/create/models/visual-detector)** — Train an object detector (YOLOF) using a different pipeline template.
+- **[Clarifai Pipelines](https://docs.clarifai.com/compute/pipelines/)** — The Pythonic-first pipeline authoring story, including the DSL for custom workflows.
+- **[Run inference on the fine-tuned model](https://docs.clarifai.com/compute/inference/)** — Use the trained LLM for predictions.

--- a/docs/getting-started/fine-tune-your-first-llm.md
+++ b/docs/getting-started/fine-tune-your-first-llm.md
@@ -50,11 +50,9 @@ To override defaults at init time — a different base model, more epochs, custo
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
-```bash
-clarifai pipeline init --template lora-pipeline-unsloth-quick-start \
+    <CodeBlock className="language-bash">{`clarifai pipeline init --template lora-pipeline-unsloth-quick-start \
   --set base_model_name="unsloth/Llama-3.2-1B-Instruct" \
-  --set num_epochs=3
-```
+  --set num_epochs=3`}</CodeBlock>
 </TabItem>
 </Tabs>
 

--- a/docs/getting-started/fine-tune-your-first-llm.md
+++ b/docs/getting-started/fine-tune-your-first-llm.md
@@ -50,8 +50,8 @@ To override defaults at init time — a different base model, more epochs, custo
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">{`clarifai pipeline init --template lora-pipeline-unsloth-quick-start \
-  --set base_model_name="unsloth/Llama-3.2-1B-Instruct" \
+    <CodeBlock className="language-bash">{`clarifai pipeline init --template lora-pipeline-unsloth-quick-start \\
+  --set base_model_name="unsloth/Llama-3.2-1B-Instruct" \\
   --set num_epochs=3`}</CodeBlock>
 </TabItem>
 </Tabs>

--- a/docs/getting-started/fine-tune-your-first-llm.md
+++ b/docs/getting-started/fine-tune-your-first-llm.md
@@ -25,7 +25,7 @@ clarifai login`}</CodeBlock>
 </TabItem>
 </Tabs>
 
-`clarifai login` auto-detects your user ID and saves your [Personal Access Token (PAT)](https://docs.clarifai.com/control/authentication/pat/) locally.
+`clarifai login` auto-detects your user ID and saves your [Personal Access Token (PAT)](https://docs.clarifai.com/control/authentication/pat) locally.
 
 ## Fine-Tune the Model
 


### PR DESCRIPTION
## Summary

Promotes LLM fine-tuning to a top-level Getting Started entry — parallel to Quick Start and Deploy. Closes the gap where training was previously only reachable via \`/create/models/\`.

## Changes

New page: \`docs/getting-started/fine-tune-your-first-llm.md\` (sidebar position 5, after the Deploy entries).

CLI-only (LoRA fine-tuning has no UI flow today). Uses the [\`lora-pipeline-unsloth-quick-start\`](https://github.com/Clarifai/pipeline-examples/tree/main/lora-pipeline-unsloth-quick-start) template — public data baked in, auto-provisioned compute, sensible LoRA defaults — so the first run is three commands with zero setup.

## Resulting sidebar

\`\`\`
GETTING STARTED
├── Quick Start With API
├── Quick Start With Playground
├── Deploy Your First Model via CLI
├── Deploy Your First Model via UI
└── Fine-Tune Your First LLM  (NEW)
\`\`\`

## On duplication with /compute/pipelines/

The page's commands overlap with the existing \`/compute/pipelines/\` Quick Start (which also demos the LoRA template). Intentional — Getting Started exists for discoverability by capability ("I want to fine-tune an LLM"); it's allowed to overlap with deeper section docs the same way "Quick Start With API" overlaps with canonical inference docs. The framing differs (capability-first vs platform-first), even though commands are the same.

## What this PR does *not* do

- No \`/create/models/llm-fine-tune.md\` page. The Getting Started entry covers discovery; a deeper LLM-specific model-type guide can wait until there's clearer demand for hyperparameter guidance.
- No merge of "Deploy via CLI" + "Deploy via UI" pages. Same anti-pattern we fixed on visual-classifier, but deserves its own focused PR.
- No rename of existing Quick Start entries. Cosmetic; current naming works.

## Test plan

- [ ] Verify the new page renders correctly in the sidebar (position 5, after Deploy entries).
- [ ] Verify the LoRA template commands work end-to-end.
- [ ] (Optional) Verify outbound links to \`/create/models/visual-classifier\`, \`/compute/pipelines/\`, \`/compute/inference/\` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)