### PR TITLE
Lead /compute/upload/ Step 2 with `clarifai model init` (Recommended)

### DIFF
--- a/docs/compute/upload/README.mdx
+++ b/docs/compute/upload/README.mdx
@@ -130,7 +130,7 @@ Let's talk about the general steps you'd follow to upload any type of model to t
 
 ### Scaffold the Project With `clarifai model init` (Recommended)
 
-The fastest way to start is to scaffold a complete model project — `model.py`, `config.yaml`, `requirements.txt`, and Dockerfile — with one command. Pick a built-in toolkit for a common inference engine, or scaffold a blank Python template you can fill in:
+The fastest way to start is to scaffold a complete model project — `model.py`, `config.yaml`, and `requirements.txt` — with one command. Pick a built-in toolkit for a common inference engine, or scaffold a blank Python template you can fill in:
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">

--- a/docs/compute/upload/README.mdx
+++ b/docs/compute/upload/README.mdx
@@ -126,7 +126,37 @@ your_model_directory/
 
 ## Step 2: Build a Model
 
-Let's talk about the general steps you'd follow to upload any type of model to the Clarifai platform. 
+Let's talk about the general steps you'd follow to upload any type of model to the Clarifai platform.
+
+### Scaffold the Project With `clarifai model init` (Recommended)
+
+The fastest way to start is to scaffold a complete model project — `model.py`, `config.yaml`, `requirements.txt`, and Dockerfile — with one command. Pick a built-in toolkit for a common inference engine, or scaffold a blank Python template you can fill in:
+
+<Tabs groupId="code">
+<TabItem value="bash" label="CLI">
+    <CodeBlock className="language-bash">{`# GPU LLM serving:
+clarifai model init --toolkit vllm --model-name Qwen/Qwen3-0.6B
+clarifai model init --toolkit sglang --model-name meta-llama/Llama-3-8B
+clarifai model init --toolkit huggingface --model-name bert-base-uncased
+
+# Local LLM servers:
+clarifai model init --toolkit ollama --model-name llama3.1
+clarifai model init --toolkit lmstudio --model-name <model>
+
+# Other use cases:
+clarifai model init --toolkit mcp my-mcp-server         # MCP tool server
+clarifai model init --toolkit openai my-openai-wrapper  # OpenAI-compatible wrapper
+
+# Blank Python template:
+clarifai model init my-model`}</CodeBlock>
+</TabItem>
+</Tabs>
+
+Each toolkit pre-fills `model.py` with a working `ModelClass` implementation, `config.yaml` with reasonable compute defaults, `requirements.txt` with the right dependencies, and a Dockerfile. After scaffolding, you can run the model locally (Step 3), upload it (Step 4), and deploy it (Step 5) — often with no further code changes.
+
+You can also clone an existing example from a GitHub URL with `clarifai model init --github-url <url>` — useful for starting from a known-good reference (see the [`runners-examples`](https://github.com/Clarifai/runners-examples) repo).
+
+The rest of this step walks through `model.py`, `config.yaml`, and `requirements.txt` in detail — either as reference for what gets generated, or as a guide if you'd rather build everything from scratch.
 
 ### Prepare `model.py` 
 

--- a/docs/compute/upload/README.mdx
+++ b/docs/compute/upload/README.mdx
@@ -141,7 +141,7 @@ clarifai model init --toolkit huggingface --model-name bert-base-uncased
 
 # Local LLM servers:
 clarifai model init --toolkit ollama --model-name llama3.1
-clarifai model init --toolkit lmstudio --model-name <model>
+clarifai model init --toolkit lmstudio --model-name llama-3.2-3b-instruct
 
 # Other use cases:
 clarifai model init --toolkit mcp my-mcp-server         # MCP tool server

--- a/docs/compute/upload/README.mdx
+++ b/docs/compute/upload/README.mdx
@@ -136,7 +136,7 @@ The fastest way to start is to scaffold a complete model project — `model.py`,
 <TabItem value="bash" label="CLI">
     <CodeBlock className="language-bash">{`# GPU LLM serving:
 clarifai model init --toolkit vllm --model-name Qwen/Qwen3-0.6B
-clarifai model init --toolkit sglang --model-name meta-llama/Llama-3-8B
+clarifai model init --toolkit sglang --model-name Qwen/Qwen3-0.6B
 clarifai model init --toolkit huggingface --model-name bert-base-uncased
 
 # Local LLM servers:

--- a/docs/compute/upload/README.mdx
+++ b/docs/compute/upload/README.mdx
@@ -152,7 +152,7 @@ clarifai model init my-model`}</CodeBlock>
 </TabItem>
 </Tabs>
 
-Each toolkit pre-fills `model.py` with a working `ModelClass` implementation, `config.yaml` with reasonable compute defaults, `requirements.txt` with the right dependencies, and a Dockerfile. After scaffolding, you can run the model locally (Step 3), upload it (Step 4), and deploy it (Step 5) — often with no further code changes.
+Each toolkit pre-fills `model.py` with a working `ModelClass` implementation, `config.yaml` with reasonable compute defaults, and `requirements.txt` with the right dependencies. After scaffolding, you can run the model locally (Step 3), upload it (Step 4), and deploy it (Step 5) — often with no further code changes.
 
 You can also clone an existing example from a GitHub URL with `clarifai model init --github-url <url>` — useful for starting from a known-good reference (see the [`runners-examples`](https://github.com/Clarifai/runners-examples) repo).
 


### PR DESCRIPTION
## Summary

The current \`/compute/upload/\` page walks readers through manually preparing \`model.py\`, \`config.yaml\`, \`requirements.txt\`, and Dockerfile. \`clarifai model init\` is mentioned three times on the page but always as a buried \"you can also...\" callout — never as the recommended starting point.

That's backwards. \`clarifai model init\` (especially with \`--toolkit vllm/sglang/huggingface/ollama/lmstudio/mcp/openai\`) is a one-command scaffold that produces a working model project. Manual file preparation is reference material, not the primary path.

## Changes

One new subsection inserted at the top of Step 2: **\"Scaffold the Project With \`clarifai model init\` (Recommended)\"**

Shows the eight built-in toolkits and the \`--github-url\` option. Frames the existing \"Prepare \`model.py\` / \`config.yaml\` / \`requirements.txt\`\" subsections as reference material for understanding what init generates (or for users building from scratch).

No existing content removed — the prep sections stay in place and remain useful as reference.

## Why now

We're sharing the \`/compute/upload/\` page externally as a proof point for the Pythonic interface to the Clarifai platform. \`clarifai model init --toolkit vllm --model-name Qwen/Qwen3-0.6B\` is a one-command Pythonic onboarding — that's the headline. Burying it loses the moment.

## Test plan

- [ ] Verify the new \"Scaffold the Project With \`clarifai model init\`\" subsection renders correctly at the top of Step 2.
- [ ] Verify the existing \"Prepare \`model.py\` / \`config.yaml\` / \`requirements.txt\`\" sections still render normally below it.
- [ ] (Optional) Spot-check that one of the toolkit init commands works end-to-end against the live CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)