### PR TITLE
Surface toolkit variants on /compute/local-runners/ Quick Start

### DIFF
--- a/docs/compute/local-runners/README.mdx
+++ b/docs/compute/local-runners/README.mdx
@@ -71,13 +71,29 @@ Connect your environment to the Clarifai platform and [create a context](#step-2
 
 ### Set up a Model
 
-Generate a sample toy [model](#step-1-build-a-model) with the necessary files.
+Scaffold a sample [model](#step-1-build-a-model) with the necessary files. You can start from a blank Python template, or pick a built-in toolkit pre-configured for your inference engine:
 
 <Tabs groupId="code">
 <TabItem value="bash" label="CLI">
-    <CodeBlock className="language-bash">clarifai model init</CodeBlock>
+    <CodeBlock className="language-bash">{`# Local LLM servers (most common for local runners):
+clarifai model init --toolkit ollama --model-name llama3.1
+clarifai model init --toolkit lmstudio --model-name <model>
+
+# GPU LLM serving (if running on a local GPU):
+clarifai model init --toolkit vllm --model-name Qwen/Qwen3-0.6B
+clarifai model init --toolkit sglang --model-name meta-llama/Llama-3-8B
+clarifai model init --toolkit huggingface --model-name bert-base-uncased
+
+# Other:
+clarifai model init --toolkit mcp my-mcp-server         # MCP tool server (FastMCP)
+clarifai model init --toolkit openai my-openai-wrapper  # OpenAI-compatible wrapper
+
+# Blank Python template:
+clarifai model init`}</CodeBlock>
 </TabItem>
 </Tabs>
+
+Each toolkit pre-fills `model.py` with a working `ModelClass` implementation, `config.yaml` with reasonable defaults, and `requirements.txt`. After scaffolding, the next step is to serve the model locally.
 
 ### Serve Your Model Locally
 


### PR DESCRIPTION
## Summary

The Quick Start on \`/compute/local-runners/\` shows \`clarifai model init\` with no toolkit args — which hides the toolkit variants that are most relevant to local runners.

Specifically: \`--toolkit ollama\` and \`--toolkit lmstudio\` are the natural fit for \"run a model locally on my hardware,\" but they're invisible on a page about exactly that workflow.

## Changes

Replace the bare \`clarifai model init\` in the \"Set up a Model\" subsection with a grouped listing of all eight toolkits, leading with the local-friendly ones:

- **Local LLM servers (most common for local runners):** ollama, lmstudio
- **GPU LLM serving (if running on a local GPU):** vllm, sglang, huggingface
- **Other:** mcp, openai
- **Blank Python template:** \`clarifai model init\`

Same pattern as the recent change to \`/compute/upload/\` (PR #882) — surface toolkit variants where they're most relevant.

## Test plan

- [ ] Verify the new code block renders correctly on the Quick Start.
- [ ] (Optional) Spot-check that \`clarifai model init --toolkit ollama --model-name llama3.1\` works against the live CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)